### PR TITLE
Add metrics to determine the message queue size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,6 +5000,7 @@ dependencies = [
  "lazy_static",
  "log",
  "prometheus",
+ "scopeguard",
  "serde",
  "serde_json",
  "solana-geyser-plugin-interface",

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -24,6 +24,7 @@ hyper = { version = "0.14.20", features = ["server"] }
 lazy_static = "1.4.0"
 log = "0.4.17"
 prometheus = "0.13.2"
+scopeguard = "1.2.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 solana-geyser-plugin-interface = "=1.17.1"

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -2,7 +2,10 @@ use {
     crate::{
         config::{ConfigBlockFailAction, ConfigGrpc},
         filters::{Filter, FilterAccountsDataSlice},
-        prom::{self, CONNECTIONS_TOTAL, MESSAGE_QUEUE_SIZE},
+        prom::{
+            self, CONNECTIONS_TOTAL, GEYSER_LOOP_HISTOGRAM, MESSAGE_QUEUE_SIZE,
+            SNAPSHOT_MESSAGE_QUEUE_SIZE,
+        },
         version::VERSION,
     },
     log::{error, info},
@@ -790,6 +793,10 @@ impl GrpcService {
         loop {
             tokio::select! {
                 Some(message) = messages_rx.recv() => {
+                    let start_time = Instant::now();
+                    let _guard = scopeguard::guard((), |_| {
+                        GEYSER_LOOP_HISTOGRAM.observe(start_time.elapsed().as_millis() as f64);
+                    });
                     MESSAGE_QUEUE_SIZE.dec();
 
                     // Update blocks info
@@ -1076,7 +1083,7 @@ impl GrpcService {
             while is_alive {
                 let message = match snapshot_rx.try_recv() {
                     Ok(message) => {
-                        MESSAGE_QUEUE_SIZE.dec();
+                        SNAPSHOT_MESSAGE_QUEUE_SIZE.dec();
                         match message {
                             Some(message) => message,
                             None => break,

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -2,7 +2,10 @@ use {
     crate::{
         config::Config,
         grpc::{GrpcService, Message},
-        prom::{self, PrometheusService, MESSAGE_QUEUE_SIZE},
+        prom::{
+            self, PrometheusService, INCOMING_MESSAGES_COUNTER, MESSAGE_QUEUE_SIZE,
+            SNAPSHOT_MESSAGE_QUEUE_SIZE,
+        },
     },
     solana_geyser_plugin_interface::geyser_plugin_interface::{
         GeyserPlugin, GeyserPluginError, ReplicaAccountInfoVersions, ReplicaBlockInfoVersions,
@@ -37,6 +40,7 @@ pub struct PluginInner {
 
 impl PluginInner {
     fn send_message(&self, message: Message) {
+        INCOMING_MESSAGES_COUNTER.inc();
         if self.grpc_channel.send(message).is_ok() {
             MESSAGE_QUEUE_SIZE.inc();
         }
@@ -137,7 +141,7 @@ impl GeyserPlugin for Plugin {
             let inner = self.inner.as_ref().expect("initialized");
             if let Some(channel) = &inner.snapshot_channel {
                 match channel.send(Some(message)) {
-                    Ok(()) => MESSAGE_QUEUE_SIZE.inc(),
+                    Ok(()) => SNAPSHOT_MESSAGE_QUEUE_SIZE.inc(),
                     Err(_) => panic!("failed to send message to startup queue: channel closed"),
                 }
             }
@@ -159,7 +163,7 @@ impl GeyserPlugin for Plugin {
 
         if let Some(channel) = &inner.snapshot_channel {
             match channel.send(None) {
-                Ok(()) => MESSAGE_QUEUE_SIZE.inc(),
+                Ok(()) => SNAPSHOT_MESSAGE_QUEUE_SIZE.inc(),
                 Err(_) => panic!("failed to send message to startup queue: channel closed"),
             }
         }

--- a/yellowstone-grpc-geyser/src/prom.rs
+++ b/yellowstone-grpc-geyser/src/prom.rs
@@ -7,7 +7,10 @@ use {
         Body, Request, Response, Server, StatusCode,
     },
     log::error,
-    prometheus::{IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder},
+    prometheus::{
+        Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
+        TextEncoder,
+    },
     solana_geyser_plugin_interface::geyser_plugin_interface::SlotStatus,
     std::sync::Once,
     tokio::sync::oneshot,
@@ -31,8 +34,20 @@ lazy_static::lazy_static! {
         &["reason"]
     ).unwrap();
 
+    pub static ref INCOMING_MESSAGES_COUNTER: IntCounter = IntCounter::new(
+        "incoming_messages_counter", "Incoming message counter"
+    ).unwrap();
+
     pub static ref MESSAGE_QUEUE_SIZE: IntGauge = IntGauge::new(
         "message_queue_size", "Size of geyser message queue"
+    ).unwrap();
+
+    pub static ref SNAPSHOT_MESSAGE_QUEUE_SIZE: IntGauge = IntGauge::new(
+        "snapshot_message_queue_size", "Size of snapshot message queue"
+    ).unwrap();
+
+    pub static ref GEYSER_LOOP_HISTOGRAM: Histogram = Histogram::with_opts(
+        HistogramOpts::new("geyser_loop_histogram", "Processing loop time")
     ).unwrap();
 
     pub static ref CONNECTIONS_TOTAL: IntGauge = IntGauge::new(
@@ -61,6 +76,9 @@ impl PrometheusService {
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
             register!(CONNECTIONS_TOTAL);
+            register!(INCOMING_MESSAGES_COUNTER);
+            register!(SNAPSHOT_MESSAGE_QUEUE_SIZE);
+            register!(GEYSER_LOOP_HISTOGRAM);
 
             VERSION
                 .with_label_values(&[


### PR DESCRIPTION
I think the client lagging shouldn't affect the messages being queued up in the grpc channel. This should help us identify potential bottlenecks. 