### PR TITLE
Compress account data using lz4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,6 +2089,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5645,6 +5654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6089,6 +6104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6525,6 +6550,7 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "log",
+ "lz4_flex",
  "prometheus",
  "prost-types 0.13.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tonic = "0.12.1"
 tonic-build = "0.12.1"
 tonic-health = "0.12.1"
 vergen = "9.0.0"
+lz4_flex = "0.11.3"
 yellowstone-grpc-client = { path = "yellowstone-grpc-client", version = "2.2.0" }
 yellowstone-grpc-proto = { path = "yellowstone-grpc-proto", version = "2.2.0", default-features = false }
 

--- a/yellowstone-grpc-geyser/Cargo.toml
+++ b/yellowstone-grpc-geyser/Cargo.toml
@@ -48,7 +48,7 @@ tokio-stream = { workspace = true }
 tonic = { workspace = true, features = ["gzip", "zstd", "tls", "tls-roots"] }
 tonic-health = { workspace = true }
 yellowstone-grpc-proto = { workspace = true, features = ["convert", "plugin"] }
-
+lz4_flex = { workspace = true }
 [build-dependencies]
 anyhow = { workspace = true }
 cargo-lock = { workspace = true }

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -45,8 +45,7 @@ use {
                 Filter,
             },
             message::{
-                CommitmentLevel, Message, MessageBlock, MessageBlockMeta, MessageEntry,
-                MessageSlot, MessageTransactionInfo,
+                CommitmentLevel, Message, MessageAccount, MessageAccountInfo, MessageBlock, MessageBlockMeta, MessageEntry, MessageSlot, MessageTransactionInfo
             },
             proto::geyser_server::{Geyser, GeyserServer},
         },
@@ -58,6 +57,7 @@ use {
         },
     },
 };
+use lz4_flex::block::compress_prepend_size;
 
 #[derive(Debug)]
 struct BlockhashStatus {
@@ -525,9 +525,77 @@ impl GrpcService {
         let (_tx, rx) = mpsc::channel(1);
         let mut replay_stored_slots_rx = replay_stored_slots_rx.unwrap_or(rx);
 
+        let num_compression_workers = 10;
+        let mut sequencer_txs = Vec::with_capacity(num_compression_workers);
+        let mut sequencer_rxs = Vec::with_capacity(num_compression_workers);
+        for _ in 0..num_compression_workers {
+            let (tx, rx) = mpsc::unbounded_channel();
+            sequencer_txs.push(tx);
+            sequencer_rxs.push(rx);
+        }
+
+        tokio::spawn(async move {
+            let mut sequence = 0;
+            while let Some(message) = messages_rx.recv().await {
+                let tx = sequencer_txs[sequence % num_compression_workers].clone();
+                tx.send((sequence, message)).unwrap();
+                sequence += 1;
+            }
+        });
+
+        let (compressed_mpsc_tx, mut compressed_mpsc_rx) = mpsc::unbounded_channel();
+        for _ in 0..num_compression_workers {
+            let mut rx = sequencer_rxs.pop().unwrap();
+            let compressed_mpsc_tx = compressed_mpsc_tx.clone();
+            tokio::spawn(async move {
+                while let Some((sequence, message)) = rx.recv().await {
+                    let mutated_message = if let Message::Account(account) = &message {
+                        let account_info = MessageAccountInfo {
+                            pubkey: account.account.pubkey,
+                            lamports: account.account.lamports,
+                            owner: account.account.owner,
+                            executable: account.account.executable,
+                            rent_epoch: account.account.rent_epoch,
+                            data: compress_prepend_size(account.account.data.as_ref()),
+                            write_version: account.account.write_version,
+                            txn_signature: account.account.txn_signature,
+                        };
+                        let message_account = MessageAccount {
+                            account: Arc::new(account_info),
+                            slot: account.slot,
+                            is_startup: account.is_startup,
+                            created_at: account.created_at,
+                        };
+                        Message::Account(message_account)
+                    } else {
+                        message
+                    };
+                    compressed_mpsc_tx.send((sequence, mutated_message)).unwrap();
+                }
+            });
+        }
+
+        let (rearrange_tx, mut rearrange_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut next_sequence = 0;
+            let mut messages: BTreeMap<usize, Message> = Default::default();
+            while let Some((sequence, message)) = compressed_mpsc_rx.recv().await {
+                messages.insert(sequence, message);
+                loop {
+                    if messages.contains_key(&next_sequence) {
+                        let message = messages.remove(&next_sequence).unwrap();
+                        rearrange_tx.send(message).unwrap();
+                        next_sequence += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        });
+
         loop {
             tokio::select! {
-                Some(message) = messages_rx.recv() => {
+                Some(message) = rearrange_rx.recv() => {
                     metrics::message_queue_size_dec();
                     let msgid = msgid_gen.next();
 

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -336,7 +336,9 @@ impl FilterAccounts {
         filter.match_account(&message.account.pubkey);
         filter.match_owner(&message.account.owner);
         filter.match_data_lamports(&message.account.data, message.account.lamports);
-        let filters = filter.get_filters();
+        // HACK: Used to indicate that the message is compressed
+        let filter_name = FilterName::new("lz4");
+        let filters = smallvec::smallvec![filter_name];
         filtered_updates_once_owned!(
             filters,
             FilteredUpdateOneof::account(message, accounts_data_slice.clone()),


### PR DESCRIPTION
# Overview

Ran some performance tests. Got:
1. 1.2GB/s for compression
2. 2.5GB/s for decompression. 

We are running 10 compression workers in parallel to achieve higher throughput. At this point, we are most likely going to be limited my memcp's in the code. 

Note:
Added a hack where the response message filter name has an "lz4" message. Will use that to determine on the laserstream side which Yellowstone nodes have been updated to use compression. 