### PR TITLE
Add aggregated client level metrics

### DIFF
--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -982,6 +982,7 @@ impl GrpcService {
             );
 
             set_subscriber_queue_size(&subscriber_id, stream_tx.queue_size());
+            CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE.set(stream_tx.queue_size() as i64);
 
             tokio::select! {
                 _ = cancellation_token.cancelled() => {
@@ -1102,7 +1103,13 @@ impl GrpcService {
                                         metrics::incr_grpc_bytes_sent(&subscriber_id, proto_size);
                                     }
                                     Err(mpsc::error::TrySendError::Full(_)) => {
-                                        error!("client #{id}: lagged to send an update");
+                                        let queue_size = stream_tx.queue_size();
+                                        let send_rate = stream_tx.estimated_send_rate().per_second();
+                                        let recv_rate = stream_tx.estimated_consuming_rate().per_second();
+                                        error!(
+                                            "client #{id}: lagged to send an update - queue_size: {}, send_rate: {} bytes/s, recv_rate: {} bytes/s, subscriber_id: {}",
+                                            queue_size, send_rate, recv_rate, subscriber_id
+                                        );
                                         task_tracker.spawn(async move {
                                             let _ = stream_tx.send(Err(Status::internal("lagged to send an update"))).await;
                                         });
@@ -1132,6 +1139,7 @@ impl GrpcService {
         set_subscriber_recv_bandwidth_load(&subscriber_id, 0);
         set_subscriber_send_bandwidth_load(&subscriber_id, 0);
         set_subscriber_queue_size(&subscriber_id, 0);
+        CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE.set(0);
 
         metrics::connections_total_dec();
         DebugClientMessage::maybe_send(&debug_client_tx, || DebugClientMessage::Removed { id });

--- a/yellowstone-grpc-geyser/src/grpc.rs
+++ b/yellowstone-grpc-geyser/src/grpc.rs
@@ -982,7 +982,7 @@ impl GrpcService {
             );
 
             set_subscriber_queue_size(&subscriber_id, stream_tx.queue_size());
-            CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE.set(stream_tx.queue_size() as i64);
+            metrics::client_stream_queue_size_set(stream_tx.queue_size() as usize);
 
             tokio::select! {
                 _ = cancellation_token.cancelled() => {
@@ -1139,7 +1139,7 @@ impl GrpcService {
         set_subscriber_recv_bandwidth_load(&subscriber_id, 0);
         set_subscriber_send_bandwidth_load(&subscriber_id, 0);
         set_subscriber_queue_size(&subscriber_id, 0);
-        CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE.set(0);
+        metrics::client_stream_queue_size_set(0);
 
         metrics::connections_total_dec();
         DebugClientMessage::maybe_send(&debug_client_tx, || DebugClientMessage::Removed { id });

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -61,14 +61,6 @@ lazy_static::lazy_static! {
         "snapshot_queue_size", "Size of snapshot queue during startup"
     ).unwrap();
 
-    static ref CLIENT_STREAM_QUEUE_SIZE_TOTAL: IntGauge = IntGauge::new(
-        "client_stream_queue_size_total", "Total size of client stream queues"
-    ).unwrap();
-
-    static ref CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE: IntGauge = IntGauge::new(
-        "client_stream_subscriber_queue_size", "Size of client stream subscriber queue"
-    ).unwrap();
-
     static ref CONNECTIONS_TOTAL: IntGauge = IntGauge::new(
         "connections_total", "Total number of connections to gRPC service"
     ).unwrap();
@@ -270,8 +262,6 @@ impl PrometheusService {
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
             register!(SNAPSHOT_QUEUE_SIZE);
-            register!(CLIENT_STREAM_QUEUE_SIZE_TOTAL);
-            register!(CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE);
             register!(CONNECTIONS_TOTAL);
             register!(SUBSCRIPTIONS_TOTAL);
             register!(MISSED_STATUS_MESSAGE);
@@ -447,14 +437,6 @@ pub fn snapshot_queue_size_inc() {
 
 pub fn snapshot_queue_size_dec() {
     SNAPSHOT_QUEUE_SIZE.dec();
-}
-
-pub fn client_stream_queue_size_set(size: usize) {
-    CLIENT_STREAM_QUEUE_SIZE_TOTAL.set(size as i64);
-}
-
-pub fn client_stream_subscriber_queue_size_set(size: usize) {
-    CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE.set(size as i64);
 }
 
 pub fn connections_total_inc() {

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -269,6 +269,9 @@ impl PrometheusService {
             register!(SLOT_STATUS_PLUGIN);
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
+            register!(SNAPSHOT_QUEUE_SIZE);
+            register!(CLIENT_STREAM_QUEUE_SIZE_TOTAL);
+            register!(CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE);
             register!(CONNECTIONS_TOTAL);
             register!(SUBSCRIPTIONS_TOTAL);
             register!(MISSED_STATUS_MESSAGE);

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -269,8 +269,6 @@ impl PrometheusService {
             register!(SLOT_STATUS_PLUGIN);
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
-            register!(SNAPSHOT_QUEUE_SIZE);
-            register!(CLIENT_STREAM_QUEUE_SIZE_TOTAL);
             register!(CONNECTIONS_TOTAL);
             register!(SUBSCRIPTIONS_TOTAL);
             register!(MISSED_STATUS_MESSAGE);
@@ -450,6 +448,10 @@ pub fn snapshot_queue_size_dec() {
 
 pub fn client_stream_queue_size_set(size: usize) {
     CLIENT_STREAM_QUEUE_SIZE_TOTAL.set(size as i64);
+}
+
+pub fn client_stream_subscriber_queue_size_set(size: usize) {
+    CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE.set(size as i64);
 }
 
 pub fn connections_total_inc() {

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -65,6 +65,10 @@ lazy_static::lazy_static! {
         "client_stream_queue_size_total", "Total size of client stream queues"
     ).unwrap();
 
+    static ref CLIENT_STREAM_SUBSCRIBER_QUEUE_SIZE: IntGauge = IntGauge::new(
+        "client_stream_subscriber_queue_size", "Size of client stream subscriber queue"
+    ).unwrap();
+
     static ref CONNECTIONS_TOTAL: IntGauge = IntGauge::new(
         "connections_total", "Total number of connections to gRPC service"
     ).unwrap();
@@ -432,18 +436,6 @@ pub fn message_queue_size_inc() {
 
 pub fn message_queue_size_dec() {
     MESSAGE_QUEUE_SIZE.dec()
-}
-
-pub fn snapshot_queue_size_inc() {
-    SNAPSHOT_QUEUE_SIZE.inc();
-}
-
-pub fn snapshot_queue_size_dec() {
-    SNAPSHOT_QUEUE_SIZE.dec();
-}
-
-pub fn client_stream_queue_size_set(size: usize) {
-    CLIENT_STREAM_QUEUE_SIZE_TOTAL.set(size as i64);
 }
 
 pub fn connections_total_inc() {

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -269,6 +269,8 @@ impl PrometheusService {
             register!(SLOT_STATUS_PLUGIN);
             register!(INVALID_FULL_BLOCKS);
             register!(MESSAGE_QUEUE_SIZE);
+            register!(SNAPSHOT_QUEUE_SIZE);
+            register!(CLIENT_STREAM_QUEUE_SIZE_TOTAL);
             register!(CONNECTIONS_TOTAL);
             register!(SUBSCRIPTIONS_TOTAL);
             register!(MISSED_STATUS_MESSAGE);
@@ -436,6 +438,18 @@ pub fn message_queue_size_inc() {
 
 pub fn message_queue_size_dec() {
     MESSAGE_QUEUE_SIZE.dec()
+}
+
+pub fn snapshot_queue_size_inc() {
+    SNAPSHOT_QUEUE_SIZE.inc();
+}
+
+pub fn snapshot_queue_size_dec() {
+    SNAPSHOT_QUEUE_SIZE.dec();
+}
+
+pub fn client_stream_queue_size_set(size: usize) {
+    CLIENT_STREAM_QUEUE_SIZE_TOTAL.set(size as i64);
 }
 
 pub fn connections_total_inc() {

--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -57,6 +57,14 @@ lazy_static::lazy_static! {
         "message_queue_size", "Size of geyser message queue"
     ).unwrap();
 
+    static ref SNAPSHOT_QUEUE_SIZE: IntGauge = IntGauge::new(
+        "snapshot_queue_size", "Size of snapshot queue during startup"
+    ).unwrap();
+
+    static ref CLIENT_STREAM_QUEUE_SIZE_TOTAL: IntGauge = IntGauge::new(
+        "client_stream_queue_size_total", "Total size of client stream queues"
+    ).unwrap();
+
     static ref CONNECTIONS_TOTAL: IntGauge = IntGauge::new(
         "connections_total", "Total number of connections to gRPC service"
     ).unwrap();
@@ -424,6 +432,18 @@ pub fn message_queue_size_inc() {
 
 pub fn message_queue_size_dec() {
     MESSAGE_QUEUE_SIZE.dec()
+}
+
+pub fn snapshot_queue_size_inc() {
+    SNAPSHOT_QUEUE_SIZE.inc();
+}
+
+pub fn snapshot_queue_size_dec() {
+    SNAPSHOT_QUEUE_SIZE.dec();
+}
+
+pub fn client_stream_queue_size_set(size: usize) {
+    CLIENT_STREAM_QUEUE_SIZE_TOTAL.set(size as i64);
 }
 
 pub fn connections_total_inc() {

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -291,7 +291,7 @@ impl GeyserPlugin for Plugin {
     }
 
     fn account_data_snapshot_notifications_enabled(&self) -> bool {
-        false
+        true
     }
 
     fn transaction_notifications_enabled(&self) -> bool {

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -183,7 +183,7 @@ impl GeyserPlugin for Plugin {
                     let message =
                         Message::Account(MessageAccount::from_geyser(account, slot, is_startup));
                     match channel.send(Box::new(message)) {
-                        Ok(()) => metrics::message_queue_size_inc(),
+                        Ok(()) => metrics::snapshot_queue_size_inc(),
                         Err(_) => {
                             if !inner.snapshot_channel_closed.swap(true, Ordering::Relaxed) {
                                 log::error!(

--- a/yellowstone-grpc-geyser/src/util/stream.rs
+++ b/yellowstone-grpc-geyser/src/util/stream.rs
@@ -199,10 +199,6 @@ where
     pub fn queue_size(&self) -> u64 {
         self.shared.queue_size.load(Ordering::Relaxed)
     }
-
-    pub fn capacity(&self) -> usize {
-        self.inner.capacity()
-    }
 }
 
 ///

--- a/yellowstone-grpc-geyser/src/util/stream.rs
+++ b/yellowstone-grpc-geyser/src/util/stream.rs
@@ -199,6 +199,10 @@ where
     pub fn queue_size(&self) -> u64 {
         self.shared.queue_size.load(Ordering::Relaxed)
     }
+
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
 }
 
 ///


### PR DESCRIPTION
Helps in account index to determine if we're draining fast enough. Also separate snapshot queue with message queue. 
Note this aggregates the entire client queues 