### PR TITLE
Buffer BPF loader programdata writes during deploys

### DIFF
--- a/yellowstone-grpc-geyser/src/metrics.rs
+++ b/yellowstone-grpc-geyser/src/metrics.rs
@@ -277,6 +277,14 @@ impl PrometheusService {
         })
     }
 
+    #[cfg(test)]
+    pub fn new_noop() -> Self {
+        Self {
+            debug_clients_statuses: None,
+            shutdown: Arc::new(Notify::new()),
+        }
+    }
+
     pub fn shutdown(self) {
         drop(self.debug_clients_statuses);
         self.shutdown.notify_one();

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -9,7 +9,9 @@ use {
         ReplicaEntryInfoVersions, ReplicaTransactionInfoVersions, Result as PluginResult,
         SlotStatus,
     },
+    solana_sdk::pubkey::Pubkey,
     std::{
+        collections::HashMap,
         concat, env,
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -40,6 +42,10 @@ pub struct PluginInner {
     grpc_shutdown: Arc<Notify>,
     prometheus: PrometheusService,
     raw_client_channels: Arc<RwLock<Vec<(u64, crossbeam_channel::Sender<Message>)>>>,
+    /// Buffer for BPF Upgradeable Loader account updates during program deployments.
+    /// Keyed by (slot, pubkey), only the highest write_version is kept per key.
+    /// Flushed when the slot reaches Processed status.
+    deploy_buffer: Mutex<HashMap<(u64, Pubkey), MessageAccount>>,
 }
 
 impl PluginInner {
@@ -59,6 +65,79 @@ impl PluginInner {
         // Then send to regular geyser_loop pipeline
         if self.grpc_channel.send(message).is_ok() {
             metrics::message_queue_size_inc();
+        }
+    }
+
+    /// BPFLoaderUpgradeab1e11111111111111111111111
+    const BPF_LOADER_UPGRADEABLE_ID: Pubkey =
+        solana_sdk::pubkey!("BPFLoaderUpgradeab1e11111111111111111111111");
+
+    /// Returns true if this account is owned by the BPF Upgradeable Loader.
+    fn is_bpf_loader_account(owner: &Pubkey) -> bool {
+        *owner == Self::BPF_LOADER_UPGRADEABLE_ID
+    }
+
+    /// Returns true if this is a non-executable BPF loader account (programdata
+    /// being written during a multi-step upload). Executable BPF accounts are
+    /// already-deployed programs whose modifications should not be buffered.
+    fn should_buffer_account(owner: &Pubkey, executable: bool) -> bool {
+        Self::is_bpf_loader_account(owner) && !executable
+    }
+
+    /// Remove a buffered entry for (slot, pubkey), if present. Called when an
+    /// executable version of the account arrives (finalization), so we don't
+    /// later flush stale non-executable data.
+    fn evict_from_deploy_buffer(&self, slot: u64, pubkey: &Pubkey) {
+        let mut buffer = self.deploy_buffer.lock().unwrap();
+        if buffer.remove(&(slot, *pubkey)).is_some() {
+            log::info!(
+                "Evicted buffered programdata for {} in slot {} (account finalized)",
+                pubkey,
+                slot
+            );
+        }
+    }
+
+    /// Buffer a BPF loader account update, keeping only the highest write_version per (slot, pubkey).
+    fn buffer_deploy_account(&self, account: MessageAccount) {
+        let key = (account.slot, *account.pubkey());
+        let mut buffer = self.deploy_buffer.lock().unwrap();
+        match buffer.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if account.write_version() > entry.get().write_version() {
+                    entry.insert(account);
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(account);
+            }
+        }
+    }
+
+    /// Flush all buffered deploy accounts for the given slot, sending them downstream.
+    fn flush_deploy_buffer(&self, slot: u64) {
+        let accounts: Vec<MessageAccount> = {
+            let mut buffer = self.deploy_buffer.lock().unwrap();
+            let keys_to_flush: Vec<(u64, Pubkey)> = buffer
+                .keys()
+                .filter(|(s, _)| *s == slot)
+                .cloned()
+                .collect();
+            keys_to_flush
+                .into_iter()
+                .filter_map(|key| buffer.remove(&key))
+                .collect()
+        };
+
+        if !accounts.is_empty() {
+            log::info!(
+                "Flushing {} buffered BPF loader account update(s) for slot {}",
+                accounts.len(),
+                slot
+            );
+            for account in accounts {
+                self.send_message(Message::Account(account));
+            }
         }
     }
 }
@@ -163,6 +242,7 @@ impl GeyserPlugin for Plugin {
             grpc_shutdown,
             prometheus,
             raw_client_channels,
+            deploy_buffer: Mutex::new(HashMap::new()),
         });
 
         Ok(())
@@ -213,12 +293,30 @@ impl GeyserPlugin for Plugin {
                     }
                 }
             } else {
-                let message =
-                    Message::Account(MessageAccount::from_geyser(account, slot, is_startup));
+                let msg_account = MessageAccount::from_geyser(account, slot, is_startup);
 
-                clickhouse_sink::event::record(message.get_latency_payload("ys_geyser_recv"));
+                if PluginInner::should_buffer_account(&msg_account.account.owner, msg_account.account.executable) {
+                    // Non-executable BPF loader account (programdata upload in progress).
+                    // Buffer and dedupe by write_version until slot is processed.
+                    clickhouse_sink::event::record(
+                        Message::Account(msg_account.clone())
+                            .get_latency_payload("ys_geyser_recv"),
+                    );
+                    inner.buffer_deploy_account(msg_account);
+                } else {
+                    // If this is an executable BPF account (finalization), evict any
+                    // buffered non-executable entries for this (slot, pubkey) so we
+                    // don't flush stale data after the finalized version.
+                    if PluginInner::is_bpf_loader_account(&msg_account.account.owner) {
+                        inner.evict_from_deploy_buffer(msg_account.slot, msg_account.pubkey());
+                    }
 
-                inner.send_message(message);
+                    let message = Message::Account(msg_account);
+                    clickhouse_sink::event::record(
+                        message.get_latency_payload("ys_geyser_recv"),
+                    );
+                    inner.send_message(message);
+                }
             }
 
             Ok(())
@@ -239,6 +337,11 @@ impl GeyserPlugin for Plugin {
         status: &SlotStatus,
     ) -> PluginResult<()> {
         self.with_inner(|inner| {
+            // Flush buffered BPF loader account updates when slot reaches Processed
+            if matches!(status, SlotStatus::Processed) {
+                inner.flush_deploy_buffer(slot);
+            }
+
             let message = Message::Slot(MessageSlot::from_geyser(slot, parent, status));
             clickhouse_sink::event::record(message.get_latency_payload("ys_geyser_recv"));
             inner.send_message(message);
@@ -340,4 +443,343 @@ pub unsafe extern "C" fn _create_plugin() -> *mut dyn GeyserPlugin {
     let plugin = Plugin::default();
     let plugin: Box<dyn GeyserPlugin> = Box::new(plugin);
     Box::into_raw(plugin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost_types::Timestamp;
+    use solana_sdk::pubkey::Pubkey;
+    use std::time::SystemTime;
+    use yellowstone_grpc_proto::plugin::message::MessageAccountInfo;
+
+    fn make_account(pubkey: Pubkey, owner: Pubkey, slot: u64, write_version: u64) -> MessageAccount {
+        MessageAccount {
+            account: Arc::new(MessageAccountInfo {
+                pubkey,
+                lamports: 1_000_000,
+                owner,
+                executable: false,
+                rent_epoch: 0,
+                data: vec![0u8; 64],
+                write_version,
+                txn_signature: None,
+            }),
+            slot,
+            is_startup: false,
+            created_at: Timestamp::from(SystemTime::now()),
+        }
+    }
+
+    fn make_test_inner() -> PluginInner {
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+        let (grpc_tx, _grpc_rx) = mpsc::unbounded_channel();
+        let (snapshot_tx, _snapshot_rx) = crossbeam_channel::unbounded();
+        PluginInner {
+            runtime,
+            snapshot_channel: Mutex::new(Some(snapshot_tx)),
+            snapshot_channel_closed: AtomicBool::new(false),
+            grpc_channel: grpc_tx,
+            grpc_shutdown: Arc::new(Notify::new()),
+            prometheus: PrometheusService::new_noop(),
+            raw_client_channels: Arc::new(RwLock::new(Vec::new())),
+            deploy_buffer: Mutex::new(HashMap::new()),
+        }
+    }
+
+    #[test]
+    fn test_should_buffer_account() {
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+
+        // Non-executable BPF account (upload in progress) => buffer
+        assert!(PluginInner::should_buffer_account(&bpf_id, false));
+
+        // Executable BPF account (deployed program) => don't buffer
+        assert!(!PluginInner::should_buffer_account(&bpf_id, true));
+
+        // Non-BPF accounts => never buffer
+        let random_owner = Pubkey::new_unique();
+        assert!(!PluginInner::should_buffer_account(&random_owner, false));
+        assert!(!PluginInner::should_buffer_account(&random_owner, true));
+    }
+
+    #[test]
+    fn test_evict_on_finalization() {
+        let inner = make_test_inner();
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+        let slot = 100;
+
+        // Simulate upload writes buffered
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, slot, 1));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, slot, 3));
+        assert!(inner.deploy_buffer.lock().unwrap().contains_key(&(slot, pubkey)));
+
+        // Finalization arrives (executable=true) => evict buffer entry
+        inner.evict_from_deploy_buffer(slot, &pubkey);
+        assert!(!inner.deploy_buffer.lock().unwrap().contains_key(&(slot, pubkey)));
+
+        // Flush should produce nothing for this pubkey
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+        let (grpc_tx, mut grpc_rx) = mpsc::unbounded_channel();
+        // Swap in a working channel to test flush
+        let inner2 = PluginInner {
+            runtime,
+            snapshot_channel: Mutex::new(None),
+            snapshot_channel_closed: AtomicBool::new(false),
+            grpc_channel: grpc_tx,
+            grpc_shutdown: Arc::new(Notify::new()),
+            prometheus: PrometheusService::new_noop(),
+            raw_client_channels: Arc::new(RwLock::new(Vec::new())),
+            deploy_buffer: Mutex::new(HashMap::new()),
+        };
+        inner2.flush_deploy_buffer(slot);
+        assert!(grpc_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_evict_does_not_affect_other_slots() {
+        let inner = make_test_inner();
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 100, 1));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 101, 2));
+
+        // Evict only slot 100
+        inner.evict_from_deploy_buffer(100, &pubkey);
+
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        assert!(!buffer.contains_key(&(100, pubkey)));
+        assert!(buffer.contains_key(&(101, pubkey)));
+    }
+
+    #[test]
+    fn test_buffer_keeps_highest_write_version() {
+        let inner = make_test_inner();
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+        let slot = 100;
+
+        // Insert write_version 1
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, slot, 1));
+        // Insert write_version 5 (higher)
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, slot, 5));
+        // Insert write_version 3 (lower, should be ignored)
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, slot, 3));
+
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        let entry = buffer.get(&(slot, pubkey)).unwrap();
+        assert_eq!(entry.write_version(), 5);
+    }
+
+    #[test]
+    fn test_buffer_separates_by_pubkey() {
+        let inner = make_test_inner();
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey_a = Pubkey::new_unique();
+        let pubkey_b = Pubkey::new_unique();
+        let slot = 100;
+
+        inner.buffer_deploy_account(make_account(pubkey_a, bpf_id, slot, 10));
+        inner.buffer_deploy_account(make_account(pubkey_b, bpf_id, slot, 20));
+
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer.get(&(slot, pubkey_a)).unwrap().write_version(), 10);
+        assert_eq!(buffer.get(&(slot, pubkey_b)).unwrap().write_version(), 20);
+    }
+
+    #[test]
+    fn test_buffer_separates_by_slot() {
+        let inner = make_test_inner();
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 100, 1));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 101, 2));
+
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer.get(&(100, pubkey)).unwrap().write_version(), 1);
+        assert_eq!(buffer.get(&(101, pubkey)).unwrap().write_version(), 2);
+    }
+
+    #[test]
+    fn test_flush_sends_and_removes_buffered_accounts() {
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+        let (grpc_tx, mut grpc_rx) = mpsc::unbounded_channel();
+        let inner = PluginInner {
+            runtime,
+            snapshot_channel: Mutex::new(None),
+            snapshot_channel_closed: AtomicBool::new(false),
+            grpc_channel: grpc_tx,
+            grpc_shutdown: Arc::new(Notify::new()),
+            prometheus: PrometheusService::new_noop(),
+            raw_client_channels: Arc::new(RwLock::new(Vec::new())),
+            deploy_buffer: Mutex::new(HashMap::new()),
+        };
+
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+
+        // Buffer 3 updates, only highest write version should survive
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 100, 1));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 100, 5));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 100, 3));
+
+        // Also buffer a different slot
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 101, 10));
+
+        // Flush slot 100 only
+        inner.flush_deploy_buffer(100);
+
+        // Should have sent exactly 1 message (the deduplicated account)
+        let msg = grpc_rx.try_recv().unwrap();
+        match msg {
+            Message::Account(account) => {
+                assert_eq!(account.write_version(), 5);
+                assert_eq!(account.slot, 100);
+            }
+            _ => panic!("expected Account message"),
+        }
+
+        // No more messages for slot 100
+        assert!(grpc_rx.try_recv().is_err());
+
+        // Slot 101 should still be in the buffer
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer.get(&(101, pubkey)).unwrap().write_version(), 10);
+    }
+
+    #[test]
+    fn test_flush_empty_buffer_is_noop() {
+        let inner = make_test_inner();
+        // Flushing an empty buffer should not panic or send any messages
+        inner.flush_deploy_buffer(100);
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn test_evict_nonexistent_key_is_noop() {
+        let inner = make_test_inner();
+        let pubkey = Pubkey::new_unique();
+        // Should not panic when evicting a key that was never buffered
+        inner.evict_from_deploy_buffer(100, &pubkey);
+        assert!(inner.deploy_buffer.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_flush_multiple_pubkeys_in_same_slot() {
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+        let (grpc_tx, mut grpc_rx) = mpsc::unbounded_channel();
+        let inner = PluginInner {
+            runtime,
+            snapshot_channel: Mutex::new(None),
+            snapshot_channel_closed: AtomicBool::new(false),
+            grpc_channel: grpc_tx,
+            grpc_shutdown: Arc::new(Notify::new()),
+            prometheus: PrometheusService::new_noop(),
+            raw_client_channels: Arc::new(RwLock::new(Vec::new())),
+            deploy_buffer: Mutex::new(HashMap::new()),
+        };
+
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey_a = Pubkey::new_unique();
+        let pubkey_b = Pubkey::new_unique();
+        let slot = 200;
+
+        // Multiple writes per pubkey, different pubkeys in the same slot
+        inner.buffer_deploy_account(make_account(pubkey_a, bpf_id, slot, 1));
+        inner.buffer_deploy_account(make_account(pubkey_a, bpf_id, slot, 4));
+        inner.buffer_deploy_account(make_account(pubkey_b, bpf_id, slot, 2));
+        inner.buffer_deploy_account(make_account(pubkey_b, bpf_id, slot, 7));
+
+        inner.flush_deploy_buffer(slot);
+
+        // Should receive exactly 2 messages (one per pubkey, each with highest write_version)
+        let mut received = Vec::new();
+        while let Ok(msg) = grpc_rx.try_recv() {
+            match msg {
+                Message::Account(account) => received.push(account),
+                _ => panic!("expected Account message"),
+            }
+        }
+        assert_eq!(received.len(), 2);
+
+        received.sort_by_key(|a| *a.pubkey());
+        let mut expected = vec![pubkey_a, pubkey_b];
+        expected.sort();
+
+        for (account, expected_pubkey) in received.iter().zip(expected.iter()) {
+            assert_eq!(account.pubkey(), expected_pubkey);
+            assert_eq!(account.slot, slot);
+        }
+
+        // Verify highest write versions were kept
+        let a_account = received.iter().find(|a| a.pubkey() == &pubkey_a).unwrap();
+        let b_account = received.iter().find(|a| a.pubkey() == &pubkey_b).unwrap();
+        assert_eq!(a_account.write_version(), 4);
+        assert_eq!(b_account.write_version(), 7);
+
+        // Buffer should be empty after flush
+        assert!(inner.deploy_buffer.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_flush_sends_to_raw_clients() {
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+        let (grpc_tx, _grpc_rx) = mpsc::unbounded_channel();
+        let (raw_tx, raw_rx) = crossbeam_channel::unbounded();
+        let raw_clients = Arc::new(RwLock::new(vec![(1u64, raw_tx)]));
+        let inner = PluginInner {
+            runtime,
+            snapshot_channel: Mutex::new(None),
+            snapshot_channel_closed: AtomicBool::new(false),
+            grpc_channel: grpc_tx,
+            grpc_shutdown: Arc::new(Notify::new()),
+            prometheus: PrometheusService::new_noop(),
+            raw_client_channels: raw_clients,
+            deploy_buffer: Mutex::new(HashMap::new()),
+        };
+
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 100, 5));
+
+        inner.flush_deploy_buffer(100);
+
+        // Raw client should also receive the flushed message
+        let msg = raw_rx.try_recv().unwrap();
+        match msg {
+            Message::Account(account) => {
+                assert_eq!(account.pubkey(), &pubkey);
+                assert_eq!(account.write_version(), 5);
+            }
+            _ => panic!("expected Account message"),
+        }
+    }
+
+    #[test]
+    fn test_buffer_preserves_account_data() {
+        let inner = make_test_inner();
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+        let slot = 100;
+
+        let mut account = make_account(pubkey, bpf_id, slot, 42);
+        Arc::make_mut(&mut account.account).lamports = 999_999;
+        Arc::make_mut(&mut account.account).data = vec![0xAB; 128];
+        inner.buffer_deploy_account(account);
+
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        let entry = buffer.get(&(slot, pubkey)).unwrap();
+        assert_eq!(entry.account.lamports, 999_999);
+        assert_eq!(entry.account.data, vec![0xAB; 128]);
+        assert_eq!(entry.account.owner, bpf_id);
+        assert_eq!(entry.account.pubkey, pubkey);
+        assert_eq!(entry.slot, slot);
+    }
 }

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -314,11 +314,15 @@ impl GeyserPlugin for Plugin {
                 if PluginInner::should_buffer_account(&msg_account.account.owner, msg_account.account.executable) {
                     // Non-executable BPF loader account (programdata upload in progress).
                     // Buffer and dedupe by write_version until slot is processed.
+                    // Wrap in Message to record latency, then unwrap to avoid cloning.
+                    let message = Message::Account(msg_account);
                     clickhouse_sink::event::record(
-                        Message::Account(msg_account.clone())
-                            .get_latency_payload("ys_geyser_recv"),
+                        message.get_latency_payload("ys_geyser_recv"),
                     );
-                    inner.buffer_deploy_account(msg_account);
+                    match message {
+                        Message::Account(account) => inner.buffer_deploy_account(account),
+                        _ => unreachable!(),
+                    }
                 } else {
                     // If this is an executable BPF account (finalization), evict any
                     // buffered non-executable entries for this (slot, pubkey) so we

--- a/yellowstone-grpc-geyser/src/plugin.rs
+++ b/yellowstone-grpc-geyser/src/plugin.rs
@@ -114,6 +114,22 @@ impl PluginInner {
         }
     }
 
+    /// Drop all buffered entries for slots older than the given finalized slot.
+    /// This prevents memory leaks if a slot never reaches Processed (e.g. skipped/dead slots).
+    fn cleanup_old_deploy_buffer_entries(&self, finalized_slot: u64) {
+        let mut buffer = self.deploy_buffer.lock().unwrap();
+        let before = buffer.len();
+        buffer.retain(|(s, _), _| *s >= finalized_slot);
+        let removed = before - buffer.len();
+        if removed > 0 {
+            log::info!(
+                "Cleaned up {} stale deploy buffer entries older than finalized slot {}",
+                removed,
+                finalized_slot
+            );
+        }
+    }
+
     /// Flush all buffered deploy accounts for the given slot, sending them downstream.
     fn flush_deploy_buffer(&self, slot: u64) {
         let accounts: Vec<MessageAccount> = {
@@ -340,6 +356,12 @@ impl GeyserPlugin for Plugin {
             // Flush buffered BPF loader account updates when slot reaches Processed
             if matches!(status, SlotStatus::Processed) {
                 inner.flush_deploy_buffer(slot);
+            }
+
+            // Clean up any stale buffer entries from slots that never reached Processed
+            // (e.g. skipped or dead slots) to prevent unbounded memory growth.
+            if matches!(status, SlotStatus::Rooted) {
+                inner.cleanup_old_deploy_buffer_entries(slot);
             }
 
             let message = Message::Slot(MessageSlot::from_geyser(slot, parent, status));
@@ -660,6 +682,36 @@ mod tests {
         inner.flush_deploy_buffer(100);
         let buffer = inner.deploy_buffer.lock().unwrap();
         assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn test_cleanup_removes_old_slots() {
+        let inner = make_test_inner();
+        let bpf_id = PluginInner::BPF_LOADER_UPGRADEABLE_ID;
+        let pubkey = Pubkey::new_unique();
+
+        // Buffer entries across multiple slots
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 98, 1));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 99, 2));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 100, 3));
+        inner.buffer_deploy_account(make_account(pubkey, bpf_id, 101, 4));
+
+        // Finalize at slot 100 — should drop slots < 100
+        inner.cleanup_old_deploy_buffer_entries(100);
+
+        let buffer = inner.deploy_buffer.lock().unwrap();
+        assert_eq!(buffer.len(), 2);
+        assert!(!buffer.contains_key(&(98, pubkey)));
+        assert!(!buffer.contains_key(&(99, pubkey)));
+        assert!(buffer.contains_key(&(100, pubkey)));
+        assert!(buffer.contains_key(&(101, pubkey)));
+    }
+
+    #[test]
+    fn test_cleanup_empty_buffer_is_noop() {
+        let inner = make_test_inner();
+        inner.cleanup_old_deploy_buffer_entries(100);
+        assert!(inner.deploy_buffer.lock().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Buffers non-executable BPF Upgradeable Loader account updates (programdata being written during multi-step program deployments), keeping only the highest `write_version` per `(slot, pubkey)`
- Flushes buffered accounts when the slot reaches `Processed` status in `update_slot_status`
- Executable BPF accounts (finalized programs) pass through immediately and evict any stale buffered entries to prevent sending outdated non-executable state after finalization
- Adds 12 unit tests covering buffering, dedup, eviction, flush, raw client forwarding, and data integrity

## Motivation
Program deployments via `BPF Upgradeable Loader: Write` can generate hundreds of writes per slot at ~6MB each (e.g. slot 405279596 had 209 modifications totaling 1.24 GiB for a single account). This causes:
1. **OOM** in both YS and LS workers
2. **Ingestion lag** due to bandwidth saturation (650MB/s–1.15GB/s limits)
3. **Customer lag** (e.g. Jupiter unable to keep up with account traffic)

## Design

| Account state | Action |
|---|---|
| `owner == BPFLoaderUpgradeab1e`, `executable == false` | **Buffer** — programdata upload in progress, dedupe by write_version |
| `owner == BPFLoaderUpgradeab1e`, `executable == true` | **Evict** buffered entry, then **send immediately** |
| Any other account | **Send immediately** — no buffering |

## Test plan
- [x] `test_should_buffer_account` — filter logic for BPF loader + executable flag
- [x] `test_buffer_keeps_highest_write_version` — dedup correctness
- [x] `test_buffer_separates_by_pubkey` — per-pubkey isolation
- [x] `test_buffer_separates_by_slot` — per-slot isolation
- [x] `test_flush_sends_and_removes_buffered_accounts` — flush sends deduped messages, clears buffer
- [x] `test_flush_multiple_pubkeys_in_same_slot` — multiple accounts flushed correctly
- [x] `test_flush_sends_to_raw_clients` — raw (LaserStream) clients also receive flushed messages
- [x] `test_flush_empty_buffer_is_noop` — no panic on empty flush
- [x] `test_evict_on_finalization` — executable flip removes buffered entry
- [x] `test_evict_does_not_affect_other_slots` — slot isolation on eviction
- [x] `test_evict_nonexistent_key_is_noop` — no panic on missing key
- [x] `test_buffer_preserves_account_data` — lamports, data, owner, pubkey integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)