### PR TITLE
fix: Flush account buffer on slot processed updates

### DIFF
--- a/yellowstone-grpc-geyser/src/account_buffer.rs
+++ b/yellowstone-grpc-geyser/src/account_buffer.rs
@@ -10,7 +10,9 @@ use {
         runtime::Runtime,
         sync::{mpsc, Notify},
     },
-    yellowstone_grpc_proto::plugin::message::{Message, MessageAccount, MessageBlockMeta},
+    yellowstone_grpc_proto::plugin::message::{
+        Message, MessageAccount, SlotStatus as MessageSlotStatus,
+    },
 };
 
 /// Forwards a message to raw clients and the grpc pipeline.
@@ -126,6 +128,15 @@ pub fn spawn_buffer_task(
                                 forward(Message::Account(account));
                             }
                         }
+                        Message::Slot(ref slot_msg)
+                            if slot_msg.status == MessageSlotStatus::Processed =>
+                        {
+                            // Flush buffer for this slot before forwarding slot processed
+                            for account in buffer.drain_slot(slot_msg.slot) {
+                                forward(Message::Account(account));
+                            }
+                            forward(msg);
+                        }
                         Message::BlockMeta(ref meta) => {
                             // Flush buffer for this slot before forwarding block_meta
                             let slot = meta.slot();
@@ -157,7 +168,9 @@ mod tests {
     use tokio::runtime::Builder;
     use yellowstone_grpc_proto::{
         geyser::SubscribeUpdateBlockMeta,
-        plugin::message::{MessageAccountInfo, MessageSlot, SlotStatus as MessageSlotStatus},
+        plugin::message::{
+            MessageAccountInfo, MessageBlockMeta, MessageSlot, SlotStatus as MessageSlotStatus,
+        },
     };
 
     struct TestHarness {
@@ -334,5 +347,90 @@ mod tests {
         h.flush();
 
         assert!(matches!(h.try_recv(), Some(Message::Slot(_))));
+    }
+
+    #[test]
+    fn test_slot_processed_flushes_buffer() {
+        let mut h = make_test_harness(1000);
+        let pk1 = Pubkey::new_unique();
+        let pk2 = Pubkey::new_unique();
+
+        // Buffer large accounts in two different slots
+        h.send(Message::Account(make_account(pk1, 1, 2000, 1)));
+        h.send(Message::Account(make_account(pk2, 2, 2000, 1)));
+
+        // Slot processed for slot 1 should flush only slot 1
+        h.send(Message::Slot(MessageSlot {
+            slot: 1,
+            parent: Some(0),
+            status: MessageSlotStatus::Processed,
+            dead_error: None,
+            created_at: Timestamp::default(),
+        }));
+        h.flush();
+
+        if let Some(Message::Account(account)) = h.try_recv() {
+            assert_eq!(account.slot, 1);
+        } else {
+            panic!("expected Account message for slot 1");
+        }
+        assert!(matches!(h.try_recv(), Some(Message::Slot(_))));
+        // Slot 2 should still be buffered
+        assert!(h.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_slot_confirmed_does_not_flush_buffer() {
+        let mut h = make_test_harness(1000);
+        let pk = Pubkey::new_unique();
+
+        h.send(Message::Account(make_account(pk, 1, 2000, 1)));
+
+        // Confirmed status should NOT flush the buffer
+        h.send(Message::Slot(MessageSlot {
+            slot: 1,
+            parent: Some(0),
+            status: MessageSlotStatus::Confirmed,
+            dead_error: None,
+            created_at: Timestamp::default(),
+        }));
+        h.flush();
+
+        // Only the slot message should pass through, not the buffered account
+        if let Some(Message::Slot(slot_msg)) = h.try_recv() {
+            assert_eq!(slot_msg.status, MessageSlotStatus::Confirmed);
+        } else {
+            panic!("expected Slot message");
+        }
+        assert!(h.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_slot_processed_dedup_then_flush() {
+        let mut h = make_test_harness(1000);
+        let pk = Pubkey::new_unique();
+
+        // Send multiple updates for the same account, buffer should keep highest write_version
+        h.send(Message::Account(make_account(pk, 1, 2000, 1)));
+        h.send(Message::Account(make_account(pk, 1, 2000, 5)));
+        h.send(Message::Account(make_account(pk, 1, 2000, 3)));
+
+        // Flush via slot processed
+        h.send(Message::Slot(MessageSlot {
+            slot: 1,
+            parent: Some(0),
+            status: MessageSlotStatus::Processed,
+            dead_error: None,
+            created_at: Timestamp::default(),
+        }));
+        h.flush();
+
+        if let Some(Message::Account(account)) = h.try_recv() {
+            assert_eq!(account.account.write_version, 5);
+        } else {
+            panic!("expected Account message");
+        }
+        assert!(matches!(h.try_recv(), Some(Message::Slot(_))));
+        assert!(h.try_recv().is_none());
     }
 }


### PR DESCRIPTION
## Summary
- **Bug:** The account buffer only flushed buffered accounts when a `BlockMeta` message arrived for a slot. There is no ordering guarantee between `BlockMeta` and slot processed updates — slot processed can arrive before `BlockMeta`. This meant buffered accounts could be sent *after* the slot processed notification, violating the requirement that all account updates for a slot must be flushed before the slot is marked as processed.
- **Fix:** Adds a flush on `Message::Slot` with `SlotStatus::Processed`, draining all buffered accounts for that slot before forwarding the processed update. Both `BlockMeta` and slot processed now independently trigger a flush for their slot — whichever arrives first drains the buffer, and the second is a no-op. These are separate requirements: accounts must be flushed before both block meta and slot processed updates.
- Adds 3 new tests: slot processed triggers flush, confirmed does *not* flush, and dedup is preserved through the slot-processed flush path.

## Test plan
- [x] `cargo test -p yellowstone-grpc-geyser account_buffer` — all 9 tests pass
- [ ] Deploy to staging and verify accounts arrive before slot processed notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)