### PR TITLE
Add CuckooFilter for Compressed Account Filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5015,6 +5021,7 @@ dependencies = [
  "prost-types 0.14.1",
  "protobuf-src",
  "serde",
+ "siphasher",
  "smallvec",
  "solana-account",
  "solana-account-decoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ maplit = "1.0.2"
 prometheus = "0.13.2"
 prost = "0.14.0"
 prost-types = "0.14.0"
+siphasher = "1"
 prost_011 = { package = "prost", version = "^0.11.9" }
 protobuf-src = "1.1.0"
 serde = "1.0.145"

--- a/yellowstone-grpc-proto/Cargo.toml
+++ b/yellowstone-grpc-proto/Cargo.toml
@@ -24,6 +24,7 @@ bytes = { workspace = true, optional = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 prost_011 = { workspace = true, optional = true }
+siphasher = { workspace = true }
 serde = { workspace = true, optional = true }
 solana-account = { workspace = true, optional = true }
 solana-account-decoder = { workspace = true, optional = true }

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -91,6 +91,26 @@ message SubscribeRequestFilterAccounts {
   repeated string owner = 3;
   repeated SubscribeRequestFilterAccountsFilter filters = 4;
   optional bool nonempty_txn_signature = 5;
+  optional CuckooFilter cuckoo_accounts_filter = 6;
+}
+
+// Hash algorithm used to build a CuckooFilter. Carried on the wire so the
+// algorithm can change in the future without breaking older clients.
+enum CuckooHashAlgorithm {
+  SIP_HASH = 0;
+}
+
+// Compact probabilistic account filter. Lets a client subscribe to very large
+// account sets (millions) by sending fingerprints (~3 bytes/account) instead of
+// explicit 32-byte pubkeys. Matching has no false negatives and <1% false
+// positives, which the client re-filters locally against its exact set.
+message CuckooFilter {
+  bytes data = 1;
+  uint32 bucket_count = 2;
+  uint32 entries_per_bucket = 3;
+  uint32 fingerprint_bits = 4;
+  uint64 hash_seed = 5;
+  CuckooHashAlgorithm hash_algorithm = 6;
 }
 
 message SubscribeRequestFilterAccountsFilter {

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -94,16 +94,12 @@ message SubscribeRequestFilterAccounts {
   optional CuckooFilter cuckoo_accounts_filter = 6;
 }
 
-// Hash algorithm used to build a CuckooFilter. Carried on the wire so the
-// algorithm can change in the future without breaking older clients.
+// Hash algorithm for a CuckooFilter (on the wire for forward-compat).
 enum CuckooHashAlgorithm {
   SIP_HASH = 0;
 }
 
-// Compact probabilistic account filter. Lets a client subscribe to very large
-// account sets (millions) by sending fingerprints (~3 bytes/account) instead of
-// explicit 32-byte pubkeys. Matching has no false negatives and <1% false
-// positives, which the client re-filters locally against its exact set.
+// Compact probabilistic account filter: fingerprints, not pubkeys. No false negatives, <1% false positives.
 message CuckooFilter {
   bytes data = 1;
   uint32 bucket_count = 2;

--- a/yellowstone-grpc-proto/src/cuckoo/constants.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/constants.rs
@@ -1,0 +1,29 @@
+/// Slots per bucket.
+pub(crate) const ENTRIES_PER_BUCKET: usize = 4;
+
+/// Target load factor. 95% occupancy is achievable with 4 entries/bucket.
+pub(crate) const LOAD_FACTOR: f64 = 0.95;
+
+/// Maximum relocations before declaring table full.
+pub(crate) const MAX_KICKS: usize = 500;
+
+/// Fingerprint size in bits. 16 bits gives ~0.0001% false positive rate.
+pub(crate) const FINGERPRINT_BITS: u32 = 16;
+
+/// Default seed for [`YellowstoneHasherBuilder`]. ASCII: "yllwstn!"
+///
+/// Serves as the stable default used by filters constructed via
+/// [`CuckooFilter::with_capacity`] or [`CompressedAccountFilterSet::with_capacity`]. The seed
+/// in use is always serialized into the proto's `hash_seed` field, so filters
+/// built with this default remain readable even if the default changes in a
+/// future version.
+///
+/// Exposed publicly so callers who want to construct a builder with the
+/// default seed explicitly (rather than via [`YellowstoneHasherBuilder::default`])
+/// can reference it by name.
+///
+/// [`YellowstoneHasherBuilder`]: crate::cuckoo::YellowstoneHasherBuilder
+/// [`CuckooFilter::with_capacity`]: crate::cuckoo::CuckooFilter::with_capacity
+/// [`CompressedAccountFilterSet::with_capacity`]: crate::cuckoo::CompressedAccountFilterSet::with_capacity
+/// [`YellowstoneHasherBuilder::default`]: crate::cuckoo::YellowstoneHasherBuilder::default
+pub const DEFAULT_HASH_SEED: u64 = 0x_796c_6c77_7374_6e21;

--- a/yellowstone-grpc-proto/src/cuckoo/constants.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/constants.rs
@@ -7,23 +7,9 @@ pub(crate) const LOAD_FACTOR: f64 = 0.95;
 /// Maximum relocations before declaring table full.
 pub(crate) const MAX_KICKS: usize = 500;
 
-/// Fingerprint size in bits. 16 bits gives ~0.0001% false positive rate.
+/// Fingerprint width. 16 bits → ~0.01% false-positive rate (2·entries/2^16).
 pub(crate) const FINGERPRINT_BITS: u32 = 16;
 
-/// Default seed for [`YellowstoneHasherBuilder`]. ASCII: "yllwstn!"
-///
-/// Serves as the stable default used by filters constructed via
-/// [`CuckooFilter::with_capacity`] or [`CompressedAccountFilterSet::with_capacity`]. The seed
-/// in use is always serialized into the proto's `hash_seed` field, so filters
-/// built with this default remain readable even if the default changes in a
-/// future version.
-///
-/// Exposed publicly so callers who want to construct a builder with the
-/// default seed explicitly (rather than via [`YellowstoneHasherBuilder::default`])
-/// can reference it by name.
-///
-/// [`YellowstoneHasherBuilder`]: crate::cuckoo::YellowstoneHasherBuilder
-/// [`CuckooFilter::with_capacity`]: crate::cuckoo::CuckooFilter::with_capacity
-/// [`CompressedAccountFilterSet::with_capacity`]: crate::cuckoo::CompressedAccountFilterSet::with_capacity
-/// [`YellowstoneHasherBuilder::default`]: crate::cuckoo::YellowstoneHasherBuilder::default
+/// Default SipHash seed (ASCII "yllwstn!"). The seed in use is always serialized into the
+/// proto `hash_seed`, so filters built with it stay readable even if this default changes.
 pub const DEFAULT_HASH_SEED: u64 = 0x_796c_6c77_7374_6e21;

--- a/yellowstone-grpc-proto/src/cuckoo/error.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/error.rs
@@ -1,32 +1,11 @@
-//! Error types for the `cuckoo` module.
-//!
-//! Errors are scoped to the method that produces them — see [`CuckooBuildError`]
-//! for build-time failures and [`TableFullError`] for `insert` failures.
-//! Callers only pattern-match on variants the method can actually produce,
-//! avoiding leaky union error types.
-//!
-//! These impl `Display`/`Error` by hand rather than via `thiserror`, because the
-//! cuckoo module is always compiled while `thiserror` is an optional dependency
-//! of this crate (only enabled by the `plugin` feature).
+//! Cuckoo module errors. `Display`/`Error` are hand-written rather than via `thiserror`
+//! (an optional dep of this crate; the cuckoo module is always compiled).
 
 use {super::constants::MAX_KICKS, std::fmt};
 
-/// Build-time error for [`CuckooFilter`] and [`CompressedAccountFilterSet`] construction.
-///
-/// Returned by [`CuckooFilter::with_capacity`], [`CuckooFilter::with_capacity_and_hasher`],
-/// and [`CompressedAccountFilterSet::with_capacity`].
-///
-/// [`CuckooFilter`]: super::filter::CuckooFilter
-/// [`CuckooFilter::with_capacity`]: super::filter::CuckooFilter::with_capacity
-/// [`CuckooFilter::with_capacity_and_hasher`]: super::filter::CuckooFilter::with_capacity_and_hasher
-/// [`CompressedAccountFilterSet`]: super::set::CompressedAccountFilterSet
-/// [`CompressedAccountFilterSet::with_capacity`]: super::set::CompressedAccountFilterSet::with_capacity
+/// `with_capacity` failure: capacity can't be allocated (next-pow2 bucket count overflows, or OOM).
 #[derive(Debug, PartialEq, Eq)]
 pub enum CuckooBuildError {
-    /// The requested capacity could not be allocated.
-    ///
-    /// Either the next power-of-two bucket count would exceed `usize::MAX`,
-    /// or the system rejected the allocation (e.g., not enough memory).
     CapacityOverflow,
 }
 
@@ -42,17 +21,8 @@ impl fmt::Display for CuckooBuildError {
 
 impl std::error::Error for CuckooBuildError {}
 
-/// Error returned when [`CuckooFilter::insert`] or [`CompressedAccountFilterSet::insert`] cannot
-/// accommodate a new item.
-///
-/// Indicates the filter reached its load limit and could not relocate an
-/// existing fingerprint after `MAX_KICKS` attempts. Typically means the filter
-/// was under-sized for the workload; rebuild with a larger `max_capacity`.
-///
-/// On error, the inserting type's state is unchanged.
-///
-/// [`CuckooFilter::insert`]: super::filter::CuckooFilter::insert
-/// [`CompressedAccountFilterSet::insert`]: super::set::CompressedAccountFilterSet::insert
+/// `insert` failure: filter full — couldn't relocate a fingerprint after `MAX_KICKS` kicks
+/// (typically under-sized). The inserting type's state is unchanged on error.
 #[derive(Debug, PartialEq, Eq)]
 pub struct TableFullError;
 

--- a/yellowstone-grpc-proto/src/cuckoo/error.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/error.rs
@@ -1,0 +1,65 @@
+//! Error types for the `cuckoo` module.
+//!
+//! Errors are scoped to the method that produces them — see [`CuckooBuildError`]
+//! for build-time failures and [`TableFullError`] for `insert` failures.
+//! Callers only pattern-match on variants the method can actually produce,
+//! avoiding leaky union error types.
+//!
+//! These impl `Display`/`Error` by hand rather than via `thiserror`, because the
+//! cuckoo module is always compiled while `thiserror` is an optional dependency
+//! of this crate (only enabled by the `plugin` feature).
+
+use {super::constants::MAX_KICKS, std::fmt};
+
+/// Build-time error for [`CuckooFilter`] and [`CompressedAccountFilterSet`] construction.
+///
+/// Returned by [`CuckooFilter::with_capacity`], [`CuckooFilter::with_capacity_and_hasher`],
+/// and [`CompressedAccountFilterSet::with_capacity`].
+///
+/// [`CuckooFilter`]: super::filter::CuckooFilter
+/// [`CuckooFilter::with_capacity`]: super::filter::CuckooFilter::with_capacity
+/// [`CuckooFilter::with_capacity_and_hasher`]: super::filter::CuckooFilter::with_capacity_and_hasher
+/// [`CompressedAccountFilterSet`]: super::set::CompressedAccountFilterSet
+/// [`CompressedAccountFilterSet::with_capacity`]: super::set::CompressedAccountFilterSet::with_capacity
+#[derive(Debug, PartialEq, Eq)]
+pub enum CuckooBuildError {
+    /// The requested capacity could not be allocated.
+    ///
+    /// Either the next power-of-two bucket count would exceed `usize::MAX`,
+    /// or the system rejected the allocation (e.g., not enough memory).
+    CapacityOverflow,
+}
+
+impl fmt::Display for CuckooBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CapacityOverflow => {
+                f.write_str("capacity overflow: requested capacity exceeds maximum")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CuckooBuildError {}
+
+/// Error returned when [`CuckooFilter::insert`] or [`CompressedAccountFilterSet::insert`] cannot
+/// accommodate a new item.
+///
+/// Indicates the filter reached its load limit and could not relocate an
+/// existing fingerprint after `MAX_KICKS` attempts. Typically means the filter
+/// was under-sized for the workload; rebuild with a larger `max_capacity`.
+///
+/// On error, the inserting type's state is unchanged.
+///
+/// [`CuckooFilter::insert`]: super::filter::CuckooFilter::insert
+/// [`CompressedAccountFilterSet::insert`]: super::set::CompressedAccountFilterSet::insert
+#[derive(Debug, PartialEq, Eq)]
+pub struct TableFullError;
+
+impl fmt::Display for TableFullError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "cuckoo table full after {MAX_KICKS} kicks")
+    }
+}
+
+impl std::error::Error for TableFullError {}

--- a/yellowstone-grpc-proto/src/cuckoo/filter.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/filter.rs
@@ -1,44 +1,10 @@
-//! Cuckoo filter implementation for probabilistic set membership.
+//! Cuckoo filter: probabilistic set membership (`insert`/`contains`/`remove`).
 //!
-//! A cuckoo filter is a space-efficient data structure that supports:
-//! - `insert`: Add an item to the set
-//! - `contains`: Check if an item is probably in the set
-//! - `remove`: Remove an item from the set
-//!
-//! Key properties:
-//! - **No false negatives**: If `contains` returns `false`, the item is definitely not in the set
-//! - **Bounded false positives**: If `contains` returns `true`, the item is probably in the set
-//!   (<1% false positive rate at full load with default configuration)
-//! - **Space efficient**: 2M items compress to ~2-3MB (vs 64MB for an explicit pubkey list)
-//! - **Deterministic hashing**: Uses SipHash-2-4 with a configurable seed, making filter
-//!   bytes wire-compatible across Rust versions and client languages
-//!
-//! # Example
-//!
-//! ```
-//! use yellowstone_grpc_proto::cuckoo::CuckooFilter;
-//!
-//! let mut filter = CuckooFilter::<&str>::with_capacity(1000).unwrap();
-//! filter.insert(&"hello").unwrap();
-//! assert!(filter.contains(&"hello"));
-//! assert!(!filter.contains(&"world"));
-//! filter.remove(&"hello");
-//! assert!(!filter.contains(&"hello"));
-//! ```
-//!
-//! # Wire Format
-//!
-//! The filter serializes to a `CuckooFilter` proto message containing:
-//! - `data`: Raw bucket bytes (little-endian u16 fingerprints)
-//! - `bucket_count`: Number of buckets (power of 2)
-//! - `entries_per_bucket`: Slots per bucket (4)
-//! - `fingerprint_bits`: Bits per fingerprint (16)
-//! - `hash_seed`: Seed for the SipHash hasher
-//!
-//! The seed is carried on the wire rather than hardcoded, so client and server
-//! produce matching hashes without needing to agree on a constant out-of-band.
-//! Cross-language clients must use SipHash-2-4 with the same seed-to-key
-//! derivation (see `YellowstoneHasherBuilder::keys_from_seed`).
+//! No false negatives; <1% false positives at full load. ~2-3MB for 2M items
+//! (vs 64MB for an explicit pubkey list). Hashing is SipHash-2-4 with a seed
+//! carried on the wire, so filters are byte-compatible across Rust versions and
+//! client languages. Wire form is the `CuckooFilter` proto (LE u16 fingerprints
+//! in `data`, plus self-describing bucket_count/entries/fp_bits/hash_seed).
 
 use {
     super::{
@@ -53,33 +19,18 @@ use {
     },
 };
 
-/// Fingerprint type. Must match FINGERPRINT_BITS.
 type Fingerprint = u16; // must match FINGERPRINT_BITS
+type Bucket = [Fingerprint; ENTRIES_PER_BUCKET]; // 0 = empty slot
 
-/// A bucket holds ENTRIES_PER_BUCKET fingerprints. Value 0 means empty slot.
-type Bucket = [Fingerprint; ENTRIES_PER_BUCKET];
-
-/// A space-efficient probabilistic set membership filter.
+/// Probabilistic set storing fingerprints, not items: ~3 bytes/item at 95% load,
+/// O(1) insert/lookup/remove.
 ///
-/// Stores fingerprints (short hashes) of items rather than items themselves,
-/// achieving ~3 bytes per item at 95% load factor. Supports insert, lookup,
-/// and delete operations with O(1) amortized cost.
+/// `T` is the item type (one filter can't mix `&str` and `u64`); `S` is the hasher,
+/// defaulting to wire-stable [`YellowstoneHasherBuilder`]. Custom hashers (via
+/// [`with_capacity_and_hasher`]) are in-process only, not wire-compatible.
 ///
-/// # Type Parameters
-///
-/// - `T`: The item type. Typed at the struct level so a single filter can only
-///   hold items of one type — you cannot accidentally mix `&str` and `u64` in
-///   the same filter.
-/// - `S`: The hasher builder. Defaults to [`YellowstoneHasherBuilder`] which
-///   uses SipHash-2-4 for stable, wire-compatible hashing. Custom hashers can
-///   be supplied via [`with_capacity_and_hasher`] for in-process use, but are
-///   not wire-compatible with the default.
-///
-/// # Footgun: `remove`
-///
-/// Calling `remove` on an item that was never inserted may accidentally remove
-/// a different item that shares the same fingerprint. For safe tracked usage,
-/// prefer [`CompressedAccountFilterSet`] which guards removes against this case.
+/// `remove` on a never-inserted item may clear a fingerprint-colliding entry; use
+/// [`CompressedAccountFilterSet`] for tracked removes.
 ///
 /// [`with_capacity_and_hasher`]: CuckooFilter::with_capacity_and_hasher
 /// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
@@ -91,30 +42,9 @@ pub struct CuckooFilter<T, S = YellowstoneHasherBuilder> {
 }
 
 impl<T> CuckooFilter<T, YellowstoneHasherBuilder> {
-    /// Creates a filter sized to hold `max_capacity` items using the default hasher.
+    /// Filter sized for `max_capacity` items using the default ([`DEFAULT_HASH_SEED`])
+    /// hasher. Errors [`CuckooBuildError::CapacityOverflow`] if it can't be allocated.
     ///
-    /// Uses [`YellowstoneHasherBuilder::default`] which seeds SipHash with
-    /// [`DEFAULT_HASH_SEED`]. The resulting filter serializes to a proto with
-    /// the default seed on the wire.
-    ///
-    /// For custom seeds or hasher builders, use [`with_capacity_and_hasher`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CuckooBuildError::CapacityOverflow`] if `max_capacity` requires
-    /// more buckets than the system can allocate.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yellowstone_grpc_proto::cuckoo::CuckooFilter;
-    ///
-    /// let mut filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
-    /// filter.insert(&42).unwrap();
-    /// assert!(filter.contains(&42));
-    /// ```
-    ///
-    /// [`with_capacity_and_hasher`]: CuckooFilter::with_capacity_and_hasher
     /// [`DEFAULT_HASH_SEED`]: crate::cuckoo::DEFAULT_HASH_SEED
     pub fn with_capacity(max_capacity: usize) -> Result<Self, CuckooBuildError> {
         Self::with_capacity_and_hasher(max_capacity, YellowstoneHasherBuilder::default())
@@ -122,35 +52,11 @@ impl<T> CuckooFilter<T, YellowstoneHasherBuilder> {
 }
 
 impl<T, S: BuildHasher> CuckooFilter<T, S> {
-    /// Creates a filter with a custom hasher builder.
-    ///
-    /// The filter's actual bucket count is rounded up to the next power of two
-    /// and adjusted for the target load factor (~95%), so the allocated capacity
-    /// may be slightly larger than `max_capacity`.
-    ///
-    /// # Wire Compatibility
-    ///
-    /// Only filters built with [`YellowstoneHasherBuilder`] are wire-compatible with
-    /// filters reconstructed via `From<&ProtoCuckooFilter>`. Custom hasher types
-    /// are useful for tests, benchmarks, and in-process scenarios where the filter
-    /// never crosses a process boundary.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CuckooBuildError::CapacityOverflow`] if the requested capacity
-    /// cannot be allocated.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yellowstone_grpc_proto::cuckoo::{CuckooFilter, YellowstoneHasherBuilder};
-    ///
-    /// let filter = CuckooFilter::<u64, YellowstoneHasherBuilder>::with_capacity_and_hasher(
-    ///     1000,
-    ///     YellowstoneHasherBuilder::default(),
-    /// ).unwrap();
-    /// assert!(!filter.contains(&42));
-    /// ```
+    /// Filter with a custom hasher. Bucket count is rounded up to a power of two at
+    /// ~95% load, so allocated capacity may exceed `max_capacity`. Only
+    /// [`YellowstoneHasherBuilder`] is wire-compatible with `From<&ProtoCuckooFilter>`;
+    /// custom hashers are in-process only (tests/benches). Errors
+    /// [`CuckooBuildError::CapacityOverflow`] if it can't be allocated.
     pub fn with_capacity_and_hasher(
         max_capacity: usize,
         hasher_builder: S,
@@ -219,20 +125,10 @@ impl<T, S: BuildHasher> CuckooFilter<T, S> {
 }
 
 impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
-    /// Inserts an item into the filter.
-    ///
-    /// Uses partial-key cuckoo hashing: when both candidate buckets are full,
-    /// an existing fingerprint is evicted and relocated to its alternate bucket.
-    /// If no relocation path succeeds within [`MAX_KICKS`] attempts, the filter
-    /// is considered saturated.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`TableFullError`] if the filter could not accommodate the item.
-    /// This typically indicates the filter was under-sized for the workload;
-    /// rebuild with a larger `max_capacity`.
-    ///
-    /// [`MAX_KICKS`]: crate::cuckoo
+    /// Inserts an item. Partial-key cuckoo: if both candidate buckets are full,
+    /// relocates an existing fingerprint to its alternate bucket. Errors
+    /// [`TableFullError`] after `MAX_KICKS` failed relocations (filter under-sized
+    /// — rebuild with a larger `max_capacity`).
     pub fn insert(&mut self, item: &T) -> Result<(), TableFullError> {
         let fp = self.fingerprint(item);
         let h = self.hash(item);
@@ -263,16 +159,10 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
         Err(TableFullError)
     }
 
-    /// Checks if an item is probably in the filter.
+    /// Probable membership: `false` = definitely absent (no false negatives),
+    /// `true` = probably present (small false-positive chance).
+    /// [`CompressedAccountFilterSet`] keeps an exact `HashSet` alongside for precise checks.
     ///
-    /// - Returns `false`: the item is definitely not in the filter (no false negatives)
-    /// - Returns `true`: the item is probably in the filter (small false positive chance)
-    ///
-    /// False positives are the fundamental tradeoff of probabilistic filters. For
-    /// exact membership checks, maintain a [`HashSet`] alongside the filter; this
-    /// is what [`CompressedAccountFilterSet`] does internally.
-    ///
-    /// [`HashSet`]: std::collections::HashSet
     /// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
     #[inline]
     pub fn contains(&self, item: &T) -> bool {
@@ -284,17 +174,9 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
         self.bucket_contains(i1, fp) || self.bucket_contains(i2, fp)
     }
 
-    /// Removes an item from the filter.
-    ///
-    /// Returns `true` if a matching fingerprint was found and cleared, `false`
-    /// if no matching fingerprint existed.
-    ///
-    /// # Warning
-    ///
-    /// Only remove items that were previously inserted. The filter stores
-    /// fingerprints, not items and removing an item that shares a fingerprint with
-    /// a different inserted item will remove the wrong entry. For safely tracked
-    /// removes, use [`CompressedAccountFilterSet`] which keeps an exact-membership guard.
+    /// Removes an item; returns whether a matching fingerprint was cleared.
+    /// Only remove previously-inserted items — a fingerprint collision can clear the
+    /// wrong entry. [`CompressedAccountFilterSet`] guards against this.
     ///
     /// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
     pub fn remove(&mut self, item: &T) -> bool {
@@ -306,8 +188,7 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
         self.try_remove_from_bucket(i1, fp) || self.try_remove_from_bucket(i2, fp)
     }
 
-    /// Extracts a fingerprint from an item's hash.
-    /// Returns upper 16 bits, ensuring non-zero (0 = empty slot).
+    /// Fingerprint from the hash's upper 16 bits, forced non-zero (0 = empty slot).
     #[inline]
     fn fingerprint(&self, item: &T) -> Fingerprint {
         let h = self.hash(item);
@@ -320,16 +201,9 @@ impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
     }
 }
 
-/// Deserializes from proto wire format.
-///
-/// The seed from `proto.hash_seed` is preserved into the reconstructed filter,
-/// so subsequent `contains` calls match what the serializing side computed.
-/// Callers do not need to negotiate a seed out-of-band.
-///
-/// Handles malformed input gracefully:
-/// - Empty data → single empty bucket
-/// - Odd bytes → truncated (via chunks_exact)
-/// - Misaligned data → incomplete buckets dropped
+/// Wire → runtime. Rebuilds the hasher from `proto.hash_seed` so `contains` matches
+/// the serializer. Malformed input is tolerated: empty → one empty bucket; stray
+/// bytes dropped via `chunks_exact`.
 impl<T> From<&ProtoCuckooFilter> for CuckooFilter<T, YellowstoneHasherBuilder> {
     fn from(proto: &ProtoCuckooFilter) -> Self {
         let hasher_builder = YellowstoneHasherBuilder::new(proto.hash_seed);
@@ -367,11 +241,7 @@ impl<T> From<&ProtoCuckooFilter> for CuckooFilter<T, YellowstoneHasherBuilder> {
     }
 }
 
-/// Serializes to proto wire format for cross-language interop.
-///
-/// The filter's seed is written to `hash_seed` so deserialization can
-/// reconstruct a matching hasher. All other parameters (bucket count,
-/// entries per bucket, fingerprint bits) are self-describing on the wire.
+/// Runtime → wire. Writes the seed to `hash_seed`; bucket geometry is self-describing.
 impl<T> From<&CuckooFilter<T, YellowstoneHasherBuilder>> for ProtoCuckooFilter {
     fn from(filter: &CuckooFilter<T, YellowstoneHasherBuilder>) -> Self {
         let data: Vec<u8> = filter

--- a/yellowstone-grpc-proto/src/cuckoo/filter.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/filter.rs
@@ -1,0 +1,852 @@
+//! Cuckoo filter implementation for probabilistic set membership.
+//!
+//! A cuckoo filter is a space-efficient data structure that supports:
+//! - `insert`: Add an item to the set
+//! - `contains`: Check if an item is probably in the set
+//! - `remove`: Remove an item from the set
+//!
+//! Key properties:
+//! - **No false negatives**: If `contains` returns `false`, the item is definitely not in the set
+//! - **Bounded false positives**: If `contains` returns `true`, the item is probably in the set
+//!   (<1% false positive rate at full load with default configuration)
+//! - **Space efficient**: 2M items compress to ~2-3MB (vs 64MB for an explicit pubkey list)
+//! - **Deterministic hashing**: Uses SipHash-2-4 with a configurable seed, making filter
+//!   bytes wire-compatible across Rust versions and client languages
+//!
+//! # Example
+//!
+//! ```
+//! use yellowstone_grpc_proto::cuckoo::CuckooFilter;
+//!
+//! let mut filter = CuckooFilter::<&str>::with_capacity(1000).unwrap();
+//! filter.insert(&"hello").unwrap();
+//! assert!(filter.contains(&"hello"));
+//! assert!(!filter.contains(&"world"));
+//! filter.remove(&"hello");
+//! assert!(!filter.contains(&"hello"));
+//! ```
+//!
+//! # Wire Format
+//!
+//! The filter serializes to a `CuckooFilter` proto message containing:
+//! - `data`: Raw bucket bytes (little-endian u16 fingerprints)
+//! - `bucket_count`: Number of buckets (power of 2)
+//! - `entries_per_bucket`: Slots per bucket (4)
+//! - `fingerprint_bits`: Bits per fingerprint (16)
+//! - `hash_seed`: Seed for the SipHash hasher
+//!
+//! The seed is carried on the wire rather than hardcoded, so client and server
+//! produce matching hashes without needing to agree on a constant out-of-band.
+//! Cross-language clients must use SipHash-2-4 with the same seed-to-key
+//! derivation (see `YellowstoneHasherBuilder::keys_from_seed`).
+
+use {
+    super::{
+        constants::*,
+        error::{CuckooBuildError, TableFullError},
+        hasher::YellowstoneHasherBuilder,
+    },
+    crate::geyser::{CuckooFilter as ProtoCuckooFilter, CuckooHashAlgorithm},
+    std::{
+        hash::{BuildHasher, Hash},
+        marker::PhantomData,
+    },
+};
+
+/// Fingerprint type. Must match FINGERPRINT_BITS.
+type Fingerprint = u16; // must match FINGERPRINT_BITS
+
+/// A bucket holds ENTRIES_PER_BUCKET fingerprints. Value 0 means empty slot.
+type Bucket = [Fingerprint; ENTRIES_PER_BUCKET];
+
+/// A space-efficient probabilistic set membership filter.
+///
+/// Stores fingerprints (short hashes) of items rather than items themselves,
+/// achieving ~3 bytes per item at 95% load factor. Supports insert, lookup,
+/// and delete operations with O(1) amortized cost.
+///
+/// # Type Parameters
+///
+/// - `T`: The item type. Typed at the struct level so a single filter can only
+///   hold items of one type — you cannot accidentally mix `&str` and `u64` in
+///   the same filter.
+/// - `S`: The hasher builder. Defaults to [`YellowstoneHasherBuilder`] which
+///   uses SipHash-2-4 for stable, wire-compatible hashing. Custom hashers can
+///   be supplied via [`with_capacity_and_hasher`] for in-process use, but are
+///   not wire-compatible with the default.
+///
+/// # Footgun: `remove`
+///
+/// Calling `remove` on an item that was never inserted may accidentally remove
+/// a different item that shares the same fingerprint. For safe tracked usage,
+/// prefer [`CompressedAccountFilterSet`] which guards removes against this case.
+///
+/// [`with_capacity_and_hasher`]: CuckooFilter::with_capacity_and_hasher
+/// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
+#[derive(Debug, Clone)]
+pub struct CuckooFilter<T, S = YellowstoneHasherBuilder> {
+    buckets: Vec<Bucket>,
+    hasher_builder: S,
+    _phantom: PhantomData<fn() -> T>,
+}
+
+impl<T> CuckooFilter<T, YellowstoneHasherBuilder> {
+    /// Creates a filter sized to hold `max_capacity` items using the default hasher.
+    ///
+    /// Uses [`YellowstoneHasherBuilder::default`] which seeds SipHash with
+    /// [`DEFAULT_HASH_SEED`]. The resulting filter serializes to a proto with
+    /// the default seed on the wire.
+    ///
+    /// For custom seeds or hasher builders, use [`with_capacity_and_hasher`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CuckooBuildError::CapacityOverflow`] if `max_capacity` requires
+    /// more buckets than the system can allocate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yellowstone_grpc_proto::cuckoo::CuckooFilter;
+    ///
+    /// let mut filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
+    /// filter.insert(&42).unwrap();
+    /// assert!(filter.contains(&42));
+    /// ```
+    ///
+    /// [`with_capacity_and_hasher`]: CuckooFilter::with_capacity_and_hasher
+    /// [`DEFAULT_HASH_SEED`]: crate::cuckoo::DEFAULT_HASH_SEED
+    pub fn with_capacity(max_capacity: usize) -> Result<Self, CuckooBuildError> {
+        Self::with_capacity_and_hasher(max_capacity, YellowstoneHasherBuilder::default())
+    }
+}
+
+impl<T, S: BuildHasher> CuckooFilter<T, S> {
+    /// Creates a filter with a custom hasher builder.
+    ///
+    /// The filter's actual bucket count is rounded up to the next power of two
+    /// and adjusted for the target load factor (~95%), so the allocated capacity
+    /// may be slightly larger than `max_capacity`.
+    ///
+    /// # Wire Compatibility
+    ///
+    /// Only filters built with [`YellowstoneHasherBuilder`] are wire-compatible with
+    /// filters reconstructed via `From<&ProtoCuckooFilter>`. Custom hasher types
+    /// are useful for tests, benchmarks, and in-process scenarios where the filter
+    /// never crosses a process boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CuckooBuildError::CapacityOverflow`] if the requested capacity
+    /// cannot be allocated.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yellowstone_grpc_proto::cuckoo::{CuckooFilter, YellowstoneHasherBuilder};
+    ///
+    /// let filter = CuckooFilter::<u64, YellowstoneHasherBuilder>::with_capacity_and_hasher(
+    ///     1000,
+    ///     YellowstoneHasherBuilder::default(),
+    /// ).unwrap();
+    /// assert!(!filter.contains(&42));
+    /// ```
+    pub fn with_capacity_and_hasher(
+        max_capacity: usize,
+        hasher_builder: S,
+    ) -> Result<Self, CuckooBuildError> {
+        let buckets_needed =
+            (max_capacity as f64 / (LOAD_FACTOR * ENTRIES_PER_BUCKET as f64)).ceil() as usize;
+
+        let bucket_count = buckets_needed
+            .checked_next_power_of_two()
+            .ok_or(CuckooBuildError::CapacityOverflow)?
+            .max(1);
+
+        let mut buckets = Vec::new();
+        buckets
+            .try_reserve_exact(bucket_count)
+            .map_err(|_| CuckooBuildError::CapacityOverflow)?;
+
+        buckets.resize(bucket_count, [0; ENTRIES_PER_BUCKET]);
+
+        Ok(Self {
+            buckets,
+            hasher_builder,
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Hashes an item using the seeded hasher.
+    #[inline]
+    fn hash<H: Hash>(&self, item: &H) -> u64 {
+        self.hasher_builder.hash_one(item)
+    }
+
+    /// Maps a hash to a bucket index using bitmask (why bucket_count is power of 2).
+    #[inline]
+    fn index(&self, hash: u64) -> usize {
+        hash as usize & (self.buckets.len() - 1)
+    }
+
+    /// Tries to insert fingerprint into an empty slot in the bucket.
+    fn try_insert_to_bucket(&mut self, index: usize, fp: Fingerprint) -> bool {
+        for slot in &mut self.buckets[index] {
+            if *slot == 0 {
+                *slot = fp;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Tries to remove one copy of fingerprint from the bucket.
+    fn try_remove_from_bucket(&mut self, index: usize, fp: Fingerprint) -> bool {
+        for slot in &mut self.buckets[index] {
+            if *slot == fp {
+                *slot = 0;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Checks if bucket contains the fingerprint.
+    #[inline]
+    fn bucket_contains(&self, index: usize, fp: Fingerprint) -> bool {
+        self.buckets[index].contains(&fp)
+    }
+}
+
+impl<T: Hash, S: BuildHasher> CuckooFilter<T, S> {
+    /// Inserts an item into the filter.
+    ///
+    /// Uses partial-key cuckoo hashing: when both candidate buckets are full,
+    /// an existing fingerprint is evicted and relocated to its alternate bucket.
+    /// If no relocation path succeeds within [`MAX_KICKS`] attempts, the filter
+    /// is considered saturated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TableFullError`] if the filter could not accommodate the item.
+    /// This typically indicates the filter was under-sized for the workload;
+    /// rebuild with a larger `max_capacity`.
+    ///
+    /// [`MAX_KICKS`]: crate::cuckoo
+    pub fn insert(&mut self, item: &T) -> Result<(), TableFullError> {
+        let fp = self.fingerprint(item);
+        let h = self.hash(item);
+        let i1 = self.index(h);
+        let i2 = i1 ^ self.index(self.hash(&fp));
+
+        if self.try_insert_to_bucket(i1, fp) {
+            return Ok(());
+        }
+        if self.try_insert_to_bucket(i2, fp) {
+            return Ok(());
+        }
+
+        let mut i = i1;
+        let mut fp = fp;
+
+        for n in 0..MAX_KICKS {
+            let slot = (n + fp as usize) % ENTRIES_PER_BUCKET;
+            std::mem::swap(&mut fp, &mut self.buckets[i][slot]);
+
+            i ^= self.index(self.hash(&fp));
+
+            if self.try_insert_to_bucket(i, fp) {
+                return Ok(());
+            }
+        }
+
+        Err(TableFullError)
+    }
+
+    /// Checks if an item is probably in the filter.
+    ///
+    /// - Returns `false`: the item is definitely not in the filter (no false negatives)
+    /// - Returns `true`: the item is probably in the filter (small false positive chance)
+    ///
+    /// False positives are the fundamental tradeoff of probabilistic filters. For
+    /// exact membership checks, maintain a [`HashSet`] alongside the filter; this
+    /// is what [`CompressedAccountFilterSet`] does internally.
+    ///
+    /// [`HashSet`]: std::collections::HashSet
+    /// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
+    #[inline]
+    pub fn contains(&self, item: &T) -> bool {
+        let fp = self.fingerprint(item);
+        let h = self.hash(item);
+        let i1 = self.index(h);
+        let i2 = i1 ^ self.index(self.hash(&fp));
+
+        self.bucket_contains(i1, fp) || self.bucket_contains(i2, fp)
+    }
+
+    /// Removes an item from the filter.
+    ///
+    /// Returns `true` if a matching fingerprint was found and cleared, `false`
+    /// if no matching fingerprint existed.
+    ///
+    /// # Warning
+    ///
+    /// Only remove items that were previously inserted. The filter stores
+    /// fingerprints, not items and removing an item that shares a fingerprint with
+    /// a different inserted item will remove the wrong entry. For safely tracked
+    /// removes, use [`CompressedAccountFilterSet`] which keeps an exact-membership guard.
+    ///
+    /// [`CompressedAccountFilterSet`]: crate::cuckoo::CompressedAccountFilterSet
+    pub fn remove(&mut self, item: &T) -> bool {
+        let fp = self.fingerprint(item);
+        let h = self.hash(item);
+        let i1 = self.index(h);
+        let i2 = i1 ^ self.index(self.hash(&fp));
+
+        self.try_remove_from_bucket(i1, fp) || self.try_remove_from_bucket(i2, fp)
+    }
+
+    /// Extracts a fingerprint from an item's hash.
+    /// Returns upper 16 bits, ensuring non-zero (0 = empty slot).
+    #[inline]
+    fn fingerprint(&self, item: &T) -> Fingerprint {
+        let h = self.hash(item);
+        let fp = (h >> 32) as u16;
+        if fp == 0 {
+            1
+        } else {
+            fp
+        }
+    }
+}
+
+/// Deserializes from proto wire format.
+///
+/// The seed from `proto.hash_seed` is preserved into the reconstructed filter,
+/// so subsequent `contains` calls match what the serializing side computed.
+/// Callers do not need to negotiate a seed out-of-band.
+///
+/// Handles malformed input gracefully:
+/// - Empty data → single empty bucket
+/// - Odd bytes → truncated (via chunks_exact)
+/// - Misaligned data → incomplete buckets dropped
+impl<T> From<&ProtoCuckooFilter> for CuckooFilter<T, YellowstoneHasherBuilder> {
+    fn from(proto: &ProtoCuckooFilter) -> Self {
+        let hasher_builder = YellowstoneHasherBuilder::new(proto.hash_seed);
+
+        if proto.data.is_empty() {
+            return Self {
+                buckets: vec![[0; ENTRIES_PER_BUCKET]; 1],
+                hasher_builder,
+                _phantom: PhantomData,
+            };
+        }
+
+        let buckets: Vec<Bucket> = proto
+            .data
+            .chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect::<Vec<u16>>()
+            .chunks_exact(ENTRIES_PER_BUCKET)
+            .map(|chunk| [chunk[0], chunk[1], chunk[2], chunk[3]])
+            .collect();
+
+        if buckets.is_empty() {
+            return Self {
+                buckets: vec![[0; ENTRIES_PER_BUCKET]; 1],
+                hasher_builder,
+                _phantom: PhantomData,
+            };
+        }
+
+        Self {
+            buckets,
+            hasher_builder,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Serializes to proto wire format for cross-language interop.
+///
+/// The filter's seed is written to `hash_seed` so deserialization can
+/// reconstruct a matching hasher. All other parameters (bucket count,
+/// entries per bucket, fingerprint bits) are self-describing on the wire.
+impl<T> From<&CuckooFilter<T, YellowstoneHasherBuilder>> for ProtoCuckooFilter {
+    fn from(filter: &CuckooFilter<T, YellowstoneHasherBuilder>) -> Self {
+        let data: Vec<u8> = filter
+            .buckets
+            .iter()
+            .flat_map(|bucket| bucket.iter())
+            .flat_map(|fp| fp.to_le_bytes())
+            .collect();
+
+        Self {
+            data,
+            bucket_count: filter.buckets.len() as u32,
+            entries_per_bucket: ENTRIES_PER_BUCKET as u32,
+            fingerprint_bits: FINGERPRINT_BITS,
+            hash_seed: filter.hasher_builder.seed(),
+            hash_algorithm: CuckooHashAlgorithm::SipHash as i32,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_filter_contains_nothing() {
+        let str_filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        assert!(!str_filter.contains(&"hello"));
+
+        let int_filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
+        assert!(!int_filter.contains(&42u64));
+    }
+
+    #[test]
+    fn insert_then_contains() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        assert!(filter.insert(&"hello").is_ok());
+        assert!(filter.contains(&"hello"));
+        assert!(!filter.contains(&"world"));
+    }
+
+    #[test]
+    fn remove_then_not_contains() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        filter.insert(&"hello").unwrap();
+        assert!(filter.contains(&"hello"));
+        assert!(filter.remove(&"hello"));
+        assert!(!filter.contains(&"hello"));
+    }
+
+    #[test]
+    fn remove_nonexistent_returns_false() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        assert!(!filter.remove(&"hello"));
+    }
+
+    #[test]
+    fn capacity_zero() {
+        let filter = CuckooFilter::<[u8; 32]>::with_capacity(0).unwrap();
+        assert!(!filter.buckets.is_empty());
+    }
+
+    #[test]
+    fn capacity_one() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(1).unwrap();
+        assert!(filter.insert(&"only").is_ok());
+        assert!(filter.contains(&"only"));
+    }
+
+    #[test]
+    fn many_inserts() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(1000).unwrap();
+        for i in 0..1000u64 {
+            let _ = filter.insert(&i);
+        }
+        assert!(filter.contains(&0u64));
+        assert!(filter.contains(&500u64));
+        assert!(filter.contains(&999u64));
+        assert!(!filter.contains(&1000u64));
+    }
+
+    #[test]
+    fn insert_returns_error_when_full() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(10).unwrap();
+        let mut table_full_seen = false;
+        for i in 0..1000u64 {
+            match filter.insert(&i) {
+                Ok(()) => {}
+                Err(TableFullError) => {
+                    table_full_seen = true;
+                    break;
+                }
+            }
+        }
+        assert!(table_full_seen, "expected TableFull error");
+    }
+
+    #[test]
+    fn proto_roundtrip() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
+        filter.insert(&1).unwrap();
+        filter.insert(&2).unwrap();
+        filter.insert(&42).unwrap();
+
+        let proto = ProtoCuckooFilter::from(&filter);
+        let restored = CuckooFilter::<u64>::from(&proto);
+
+        assert!(restored.contains(&1));
+        assert!(restored.contains(&2));
+        assert!(restored.contains(&42));
+        assert!(!restored.contains(&999));
+    }
+
+    #[test]
+    fn bucket_count_is_power_of_two() {
+        for cap in [1, 10, 100, 1000, 1337, 10000] {
+            let filter = CuckooFilter::<u64>::with_capacity(cap).unwrap();
+            let len = filter.buckets.len();
+            assert!(len.is_power_of_two(), "capacity {cap} gave {len} buckets");
+        }
+    }
+
+    #[test]
+    fn capacity_usize_max() {
+        let result = CuckooFilter::<u64>::with_capacity(usize::MAX);
+        assert!(matches!(result, Err(CuckooBuildError::CapacityOverflow)));
+    }
+
+    #[test]
+    fn capacity_usize_max_minus_one() {
+        let result = CuckooFilter::<u64>::with_capacity(usize::MAX - 1);
+        assert!(matches!(result, Err(CuckooBuildError::CapacityOverflow)));
+    }
+
+    #[test]
+    fn insert_same_item_thousand_times() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        for _ in 0..1000 {
+            let _ = filter.insert(&"same");
+        }
+        assert!(filter.contains(&"same"));
+    }
+
+    #[test]
+    fn insert_after_remove_same_item() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        filter.insert(&"hello").unwrap();
+        filter.remove(&"hello");
+        assert!(filter.insert(&"hello").is_ok());
+        assert!(filter.contains(&"hello"));
+    }
+
+    #[test]
+    fn remove_same_item_twice() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        filter.insert(&"hello").unwrap();
+        assert!(filter.remove(&"hello"));
+        assert!(!filter.remove(&"hello"));
+    }
+
+    #[test]
+    fn proto_empty_data() {
+        let proto = ProtoCuckooFilter {
+            data: vec![],
+            bucket_count: 0,
+            entries_per_bucket: 4,
+            fingerprint_bits: 16,
+            hash_seed: DEFAULT_HASH_SEED,
+            hash_algorithm: CuckooHashAlgorithm::SipHash as i32,
+        };
+        let filter = CuckooFilter::<&str>::from(&proto);
+        assert!(!filter.contains(&"anything"));
+    }
+
+    #[test]
+    fn proto_odd_bytes() {
+        let proto = ProtoCuckooFilter {
+            data: vec![1, 2, 3],
+            bucket_count: 1,
+            entries_per_bucket: 4,
+            fingerprint_bits: 16,
+            hash_seed: DEFAULT_HASH_SEED,
+            hash_algorithm: CuckooHashAlgorithm::SipHash as i32,
+        };
+        let filter = CuckooFilter::<&str>::from(&proto);
+        // should not panic, truncates odd byte
+        let _ = filter.contains(&"test");
+    }
+
+    #[test]
+    fn proto_not_aligned_to_bucket() {
+        let proto = ProtoCuckooFilter {
+            data: vec![1, 0, 2, 0],
+            bucket_count: 1,
+            entries_per_bucket: 4,
+            fingerprint_bits: 16,
+            hash_seed: DEFAULT_HASH_SEED,
+            hash_algorithm: CuckooHashAlgorithm::SipHash as i32,
+        };
+        let filter = CuckooFilter::<&str>::from(&proto);
+        let _ = filter.contains(&"test");
+    }
+
+    #[test]
+    fn proto_lies_about_bucket_count() {
+        let proto = ProtoCuckooFilter {
+            data: vec![0; 8],
+            bucket_count: 10,
+            entries_per_bucket: 4,
+            fingerprint_bits: 16,
+            hash_seed: DEFAULT_HASH_SEED,
+            hash_algorithm: CuckooHashAlgorithm::SipHash as i32,
+        };
+        let filter = CuckooFilter::<&str>::from(&proto);
+        let _ = filter.contains(&"test");
+    }
+
+    #[test]
+    fn items_with_zero_hash() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
+        filter.insert(&0u64).unwrap();
+        assert!(filter.contains(&0u64));
+    }
+
+    #[test]
+    fn items_with_max_hash() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
+        filter.insert(&u64::MAX).unwrap();
+        assert!(filter.contains(&u64::MAX));
+    }
+
+    #[test]
+    fn empty_string() {
+        let mut filter = CuckooFilter::<&str>::with_capacity(100).unwrap();
+        filter.insert(&"").unwrap();
+        assert!(filter.contains(&""));
+    }
+
+    #[test]
+    fn very_long_string() {
+        let long = "a".repeat(1_000_000);
+        let mut filter = CuckooFilter::<String>::with_capacity(100).unwrap();
+        filter.insert(&long).unwrap();
+        assert!(filter.contains(&long));
+    }
+
+    #[test]
+    fn fill_then_remove_then_fill() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(50).unwrap();
+
+        for i in 0..50u64 {
+            let _ = filter.insert(&i);
+        }
+
+        for i in 0..50u64 {
+            filter.remove(&i);
+        }
+
+        for i in 100..150u64 {
+            assert!(
+                filter.insert(&i).is_ok(),
+                "failed to insert {i} after remove cycle"
+            );
+        }
+    }
+
+    #[test]
+    fn false_positive_rate() {
+        let n = 10_000;
+        let mut filter = CuckooFilter::<u64>::with_capacity(n).unwrap();
+
+        for i in 0..n as u64 {
+            let _ = filter.insert(&i);
+        }
+
+        let mut false_positives = 0;
+        let test_count = 100_000;
+        for i in n as u64..(n as u64 + test_count) {
+            if filter.contains(&i) {
+                false_positives += 1;
+            }
+        }
+
+        let fp_rate = false_positives as f64 / test_count as f64;
+        println!("False positive rate: {:.4}%", fp_rate * 100.0);
+
+        assert!(
+            fp_rate < 0.01,
+            "false positive rate too high: {:.4}%",
+            fp_rate * 100.0
+        );
+    }
+
+    #[test]
+    fn pubkey_like_data() {
+        // 32-byte arrays like Solana pubkeys
+        let mut filter = CuckooFilter::<[u8; 32]>::with_capacity(1000).unwrap();
+
+        for i in 0..100u8 {
+            let pubkey = [i; 32];
+            filter.insert(&pubkey).unwrap();
+        }
+
+        for i in 0..100u8 {
+            let pubkey = [i; 32];
+            assert!(filter.contains(&pubkey));
+        }
+
+        // not inserted
+        let missing = [255u8; 32];
+        assert!(!filter.contains(&missing));
+    }
+
+    #[test]
+    fn similar_pubkeys() {
+        // pubkeys that differ by one byte
+        let mut filter = CuckooFilter::<[u8; 32]>::with_capacity(100).unwrap();
+
+        let pk1 = [0u8; 32];
+        let mut pk2 = [0u8; 32];
+        pk2[31] = 1;
+
+        filter.insert(&pk1).unwrap();
+
+        assert!(filter.contains(&pk1));
+        assert!(!filter.contains(&pk2));
+    }
+
+    #[test]
+    fn deterministic_behavior() {
+        let mut filter1 = CuckooFilter::<u64>::with_capacity(100).unwrap();
+        let mut filter2 = CuckooFilter::<u64>::with_capacity(100).unwrap();
+
+        for i in 0..50u64 {
+            filter1.insert(&i).unwrap();
+            filter2.insert(&i).unwrap();
+        }
+
+        let proto1 = ProtoCuckooFilter::from(&filter1);
+        let proto2 = ProtoCuckooFilter::from(&filter2);
+
+        assert_eq!(proto1.data, proto2.data);
+    }
+
+    #[test]
+    fn proto_roundtrip_preserves_state() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
+        for i in 0..50u64 {
+            filter.insert(&i).unwrap();
+        }
+
+        let proto1 = ProtoCuckooFilter::from(&filter);
+        let restored1 = CuckooFilter::<u64>::from(&proto1);
+        let proto2 = ProtoCuckooFilter::from(&restored1);
+        let restored2 = CuckooFilter::<u64>::from(&proto2);
+
+        assert_eq!(proto1.data, proto2.data);
+
+        for i in 0..50u64 {
+            assert!(restored2.contains(&i));
+        }
+    }
+
+    #[test]
+    fn hundred_thousand_items() {
+        let n = 100_000;
+        let mut filter = CuckooFilter::<u64>::with_capacity(n).unwrap();
+
+        let mut inserted = 0;
+        for i in 0..n as u64 {
+            if filter.insert(&i).is_ok() {
+                inserted += 1;
+            }
+        }
+
+        println!("Inserted {inserted} / {n} items");
+        assert!(inserted > n * 90 / 100, "should insert at least 90%");
+    }
+
+    #[test]
+    fn proto_size_at_scale() {
+        let n = 100_000;
+        let mut filter = CuckooFilter::<u64>::with_capacity(n).unwrap();
+
+        for i in 0..n as u64 {
+            let _ = filter.insert(&i);
+        }
+
+        let proto = ProtoCuckooFilter::from(&filter);
+        let size_bytes = proto.data.len();
+        let size_mb = size_bytes as f64 / (1024.0 * 1024.0);
+
+        println!("Filter size for {n} items: {size_bytes} bytes ({size_mb:.2} MB)");
+
+        // n u64s * 8 bytes = 800KB raw; filter should be smaller
+        assert!(size_bytes < 1024 * 1024, "filter too large");
+    }
+
+    #[test]
+    fn interleaved_insert_remove_contains() {
+        let mut filter = CuckooFilter::<u64>::with_capacity(100).unwrap();
+
+        for i in 1..=50u64 {
+            filter.insert(&i).unwrap();
+        }
+
+        for i in (2..=50u64).step_by(2) {
+            filter.remove(&i);
+        }
+
+        for i in 51..=75u64 {
+            filter.insert(&i).unwrap();
+        }
+
+        for i in (1..=50u64).step_by(2) {
+            assert!(filter.contains(&i), "{i} should exist");
+        }
+
+        for i in (2..=50u64).step_by(2) {
+            assert!(!filter.contains(&i), "{i} should be gone");
+        }
+
+        for i in 51..=75u64 {
+            assert!(filter.contains(&i), "{i} should exist");
+        }
+    }
+
+    #[test]
+    fn insert_at_exact_capacity() {
+        let cap = 64;
+        let mut filter = CuckooFilter::<u64>::with_capacity(cap).unwrap();
+
+        let mut inserted = 0;
+        for i in 0..cap as u64 {
+            if filter.insert(&i).is_ok() {
+                inserted += 1;
+            }
+        }
+
+        println!("Inserted {inserted} at capacity {cap}");
+        assert!(inserted >= cap * 80 / 100);
+    }
+
+    #[test]
+    fn capacity_not_power_of_two() {
+        for cap in [7, 13, 99, 1000, 1337, 9999] {
+            let filter = CuckooFilter::<u64>::with_capacity(cap).unwrap();
+            assert!(filter.buckets.len().is_power_of_two());
+            assert!(filter.buckets.len() * ENTRIES_PER_BUCKET >= cap);
+        }
+    }
+
+    #[test]
+    fn error_types_are_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CuckooBuildError>();
+        assert_send_sync::<TableFullError>();
+    }
+
+    #[test]
+    fn filter_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CuckooFilter<[u8; 32]>>();
+    }
+
+    #[test]
+    fn custom_hasher_builder() {
+        use std::collections::hash_map::RandomState;
+
+        let hasher = RandomState::new();
+        let mut filter =
+            CuckooFilter::<&str, RandomState>::with_capacity_and_hasher(100, hasher).unwrap();
+
+        filter.insert(&"hello").unwrap();
+        assert!(filter.contains(&"hello"));
+        assert!(!filter.contains(&"world"));
+    }
+}

--- a/yellowstone-grpc-proto/src/cuckoo/hasher.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/hasher.rs
@@ -1,0 +1,109 @@
+//! Stable, wire-compatible hasher for [`CuckooFilter`].
+//!
+//! Provides [`YellowstoneHasherBuilder`], a `BuildHasher` backed by SipHash-2-4.
+//! The hasher's seed is serialized into the proto wire format so that client
+//! and server reproduce identical hashes without coordinating constants
+//! out-of-band.
+//!
+//! # Why Not `std::hash::DefaultHasher`
+//!
+//! The standard library's `DefaultHasher` is explicitly documented as
+//! implementation-defined, its algorithm can change across Rust releases.
+//! For a filter whose semantics depend on producing identical hashes in
+//! separate processes (possibly built with different Rust versions, possibly
+//! in different languages), algorithm stability is mandatory.
+//!
+//! [`CuckooFilter`]: super::filter::CuckooFilter
+
+use {siphasher::sip::SipHasher24, std::hash::BuildHasher};
+
+/// Deterministic `BuildHasher` backed by SipHash-2-4.
+///
+/// Uses SipHash rather than [`std::hash::DefaultHasher`] because
+/// `DefaultHasher`'s algorithm is an implementation detail of the Rust
+/// standard library and can change across releases. SipHash is a stable,
+/// specified algorithm with implementations in every major language,
+/// making filter bytes interoperable across Rust versions and across
+/// client languages.
+///
+/// The seed is stored on the builder (not hardcoded) and is written into
+/// the proto's `hash_seed` field at serialization. Deserialization reads
+/// the seed back, ensuring wire-compatible hashing regardless of which
+/// default either side was built with.
+///
+/// This is the default `S` type parameter for [`CuckooFilter`].
+///
+/// [`CuckooFilter`]: super::filter::CuckooFilter
+#[derive(Debug, Clone)]
+pub struct YellowstoneHasherBuilder {
+    seed: u64,
+}
+
+impl YellowstoneHasherBuilder {
+    /// Creates a builder with the given seed.
+    ///
+    /// Most callers should use [`YellowstoneHasherBuilder::default`] for
+    /// construction — it uses [`DEFAULT_HASH_SEED`], which is the seed all
+    /// standard filters serialize with.
+    ///
+    /// Use `new` when reconstructing a builder from a seed read off the wire
+    /// (e.g. via `From<&ProtoCuckooFilter>`), or when intentionally choosing
+    /// a non-default seed for a filter that will interoperate with a peer
+    /// using the same seed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yellowstone_grpc_proto::cuckoo::YellowstoneHasherBuilder;
+    ///
+    /// let builder = YellowstoneHasherBuilder::new(0xDEADBEEF);
+    /// assert_eq!(builder.seed(), 0xDEADBEEF);
+    /// ```
+    ///
+    /// [`DEFAULT_HASH_SEED`]: super::constants::DEFAULT_HASH_SEED
+    pub const fn new(seed: u64) -> Self {
+        Self { seed }
+    }
+
+    /// Returns the seed this builder hashes with.
+    ///
+    /// Used by [`CuckooFilter`]'s proto serialization to write `hash_seed` onto
+    /// the wire, enabling the receiver to reconstruct a matching hasher.
+    ///
+    /// [`CuckooFilter`]: super::filter::CuckooFilter
+    pub const fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// Derives SipHash's two keys (k0, k1) from a single seed.
+    ///
+    /// SipHash-2-4 takes two 64-bit keys. We expose one seed on the wire and
+    /// derive the second deterministically:
+    ///
+    /// - `k0 = seed`
+    /// - `k1 = seed.rotate_left(32)`
+    ///
+    /// Cross-language implementations must use the exact same derivation to
+    /// produce matching hashes. The rotation direction (left), the rotation
+    /// amount (32 bits), and the assignment of `seed` to `k0` (not `k1`) are
+    /// all part of the wire contract and cannot be changed without breaking
+    /// every existing serialized filter.
+    pub(crate) const fn keys_from_seed(seed: u64) -> (u64, u64) {
+        (seed, seed.rotate_left(32))
+    }
+}
+
+impl Default for YellowstoneHasherBuilder {
+    fn default() -> Self {
+        Self::new(super::constants::DEFAULT_HASH_SEED)
+    }
+}
+
+impl BuildHasher for YellowstoneHasherBuilder {
+    type Hasher = SipHasher24;
+
+    fn build_hasher(&self) -> SipHasher24 {
+        let (k0, k1) = Self::keys_from_seed(self.seed);
+        SipHasher24::new_with_keys(k0, k1)
+    }
+}

--- a/yellowstone-grpc-proto/src/cuckoo/hasher.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/hasher.rs
@@ -1,93 +1,32 @@
-//! Stable, wire-compatible hasher for [`CuckooFilter`].
-//!
-//! Provides [`YellowstoneHasherBuilder`], a `BuildHasher` backed by SipHash-2-4.
-//! The hasher's seed is serialized into the proto wire format so that client
-//! and server reproduce identical hashes without coordinating constants
-//! out-of-band.
-//!
-//! # Why Not `std::hash::DefaultHasher`
-//!
-//! The standard library's `DefaultHasher` is explicitly documented as
-//! implementation-defined, its algorithm can change across Rust releases.
-//! For a filter whose semantics depend on producing identical hashes in
-//! separate processes (possibly built with different Rust versions, possibly
-//! in different languages), algorithm stability is mandatory.
-//!
-//! [`CuckooFilter`]: super::filter::CuckooFilter
+//! Stable, wire-compatible hasher for the cuckoo filter: SipHash-2-4 with the seed carried
+//! on the wire, so client and server (possibly different languages/Rust versions) hash
+//! identically. std's `DefaultHasher` is implementation-defined and can't be relied on here.
 
 use {siphasher::sip::SipHasher24, std::hash::BuildHasher};
 
-/// Deterministic `BuildHasher` backed by SipHash-2-4.
-///
-/// Uses SipHash rather than [`std::hash::DefaultHasher`] because
-/// `DefaultHasher`'s algorithm is an implementation detail of the Rust
-/// standard library and can change across releases. SipHash is a stable,
-/// specified algorithm with implementations in every major language,
-/// making filter bytes interoperable across Rust versions and across
-/// client languages.
-///
-/// The seed is stored on the builder (not hardcoded) and is written into
-/// the proto's `hash_seed` field at serialization. Deserialization reads
-/// the seed back, ensuring wire-compatible hashing regardless of which
-/// default either side was built with.
-///
-/// This is the default `S` type parameter for [`CuckooFilter`].
-///
-/// [`CuckooFilter`]: super::filter::CuckooFilter
+/// Deterministic `BuildHasher` backed by SipHash-2-4 (stable + cross-language, unlike
+/// `std::hash::DefaultHasher`). The seed is serialized to the proto `hash_seed` so the
+/// receiver reconstructs a matching hasher. Default `S` for `CuckooFilter`.
 #[derive(Debug, Clone)]
 pub struct YellowstoneHasherBuilder {
     seed: u64,
 }
 
 impl YellowstoneHasherBuilder {
-    /// Creates a builder with the given seed.
-    ///
-    /// Most callers should use [`YellowstoneHasherBuilder::default`] for
-    /// construction — it uses [`DEFAULT_HASH_SEED`], which is the seed all
-    /// standard filters serialize with.
-    ///
-    /// Use `new` when reconstructing a builder from a seed read off the wire
-    /// (e.g. via `From<&ProtoCuckooFilter>`), or when intentionally choosing
-    /// a non-default seed for a filter that will interoperate with a peer
-    /// using the same seed.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yellowstone_grpc_proto::cuckoo::YellowstoneHasherBuilder;
-    ///
-    /// let builder = YellowstoneHasherBuilder::new(0xDEADBEEF);
-    /// assert_eq!(builder.seed(), 0xDEADBEEF);
-    /// ```
-    ///
-    /// [`DEFAULT_HASH_SEED`]: super::constants::DEFAULT_HASH_SEED
+    /// Builds a hasher with `seed`. Prefer `default()` (uses `DEFAULT_HASH_SEED`) unless
+    /// reconstructing from a wire seed or pairing with a peer's chosen seed.
     pub const fn new(seed: u64) -> Self {
         Self { seed }
     }
 
-    /// Returns the seed this builder hashes with.
-    ///
-    /// Used by [`CuckooFilter`]'s proto serialization to write `hash_seed` onto
-    /// the wire, enabling the receiver to reconstruct a matching hasher.
-    ///
-    /// [`CuckooFilter`]: super::filter::CuckooFilter
+    /// The seed this builder hashes with (serialized to the proto `hash_seed`).
     pub const fn seed(&self) -> u64 {
         self.seed
     }
 
-    /// Derives SipHash's two keys (k0, k1) from a single seed.
-    ///
-    /// SipHash-2-4 takes two 64-bit keys. We expose one seed on the wire and
-    /// derive the second deterministically:
-    ///
-    /// - `k0 = seed`
-    /// - `k1 = seed.rotate_left(32)`
-    ///
-    /// Cross-language implementations must use the exact same derivation to
-    /// produce matching hashes. The rotation direction (left), the rotation
-    /// amount (32 bits), and the assignment of `seed` to `k0` (not `k1`) are
-    /// all part of the wire contract and cannot be changed without breaking
-    /// every existing serialized filter.
+    /// SipHash-2-4 takes two 64-bit keys; we carry one seed on the wire and derive
+    /// `(k0, k1) = (seed, seed.rotate_left(32))`. This derivation is part of the wire
+    /// contract — peers must match it, and changing it breaks every serialized filter.
     pub(crate) const fn keys_from_seed(seed: u64) -> (u64, u64) {
         (seed, seed.rotate_left(32))
     }

--- a/yellowstone-grpc-proto/src/cuckoo/mod.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/mod.rs
@@ -1,0 +1,86 @@
+//! Compressed account filtering via cuckoo filters.
+//!
+//! This module provides a probabilistic account filter for subscribe requests,
+//! aimed at clients tracking large pubkey sets (e.g., hundreds of thousands to
+//! millions). Instead of uploading an explicit pubkey list every few seconds,
+//! the client uploads a compact cuckoo filter — typically ~3 bytes per pubkey
+//! at 95% load — and the server matches accounts against it.
+//!
+//! # Primary API
+//!
+//! - [`CompressedAccountFilterSet`] — safe, tracked client-side wrapper. Use this
+//!   to build filters. Requires the `convert` feature (enabled by default).
+//! - [`CuckooFilter`] — raw filter used for server-side matching. Has a `remove`
+//!   footgun; clients should prefer [`CompressedAccountFilterSet`].
+//!
+//! # Example — build, subscribe, then update without resubmitting the full list
+//!
+//! ```no_run
+//! use {
+//!     solana_pubkey::Pubkey,
+//!     yellowstone_grpc_proto::{cuckoo::CompressedAccountFilterSet, geyser::SubscribeRequest},
+//! };
+//!
+//! // 1. Build the cuckoo map for the accounts we track
+//! let mut accounts = CompressedAccountFilterSet::with_capacity(2_000_000).unwrap();
+//! for pk in my_tracked_pubkeys() {
+//!     accounts.insert(pk).unwrap();
+//! }
+//!
+//! // 2. Attach the compact filter to the subscribe request under a name we choose
+//! let mut req = SubscribeRequest::default();
+//! accounts.insert_into_subscribe_request(&mut req, "tracked_accounts");
+//! //    send `req` to the server...
+//!
+//! // 3. Mutate the tracked set as it changes
+//! accounts.insert(Pubkey::new_from_array([7u8; 32])).unwrap();
+//! accounts.remove(Pubkey::new_from_array([3u8; 32]));
+//!
+//! // 4. Only re-send when something changed — the filter is tiny, so a full
+//! //    re-send is cheap (no incremental-update protocol needed)
+//! if accounts.take_dirty() {
+//!     accounts.insert_into_subscribe_request(&mut req, "tracked_accounts");
+//!     // re-send `req` on the existing stream sink
+//! }
+//!
+//! # fn my_tracked_pubkeys() -> Vec<Pubkey> { vec![] }
+//! ```
+//!
+//! # Handling updates
+//!
+//! Account updates flowing in from the server may include false positives
+//! (bounded at <1% at full load). Filter locally with [`CompressedAccountFilterSet::contains`]
+//! for an exact check:
+//!
+//! ```no_run
+//! # use {
+//! #     solana_pubkey::Pubkey,
+//! #     yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet,
+//! # };
+//! # let accounts: CompressedAccountFilterSet = CompressedAccountFilterSet::with_capacity(100).unwrap();
+//! # let incoming_pubkey = Pubkey::new_from_array([0u8; 32]);
+//! if accounts.contains(incoming_pubkey) {
+//!     // definitely a tracked account
+//! } else {
+//!     // false positive from the server-side cuckoo check — ignore
+//! }
+//! ```
+
+mod constants;
+mod error;
+mod filter;
+mod hasher;
+// `set` provides the client-side builder and needs `solana-pubkey`, which is
+// supplied by the `convert` feature. The server only needs the raw filter below.
+#[cfg(feature = "convert")]
+mod set;
+
+pub use {
+    constants::DEFAULT_HASH_SEED,
+    error::{CuckooBuildError, TableFullError},
+    filter::CuckooFilter,
+    hasher::YellowstoneHasherBuilder,
+};
+
+#[cfg(feature = "convert")]
+pub use set::CompressedAccountFilterSet;

--- a/yellowstone-grpc-proto/src/cuckoo/mod.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/mod.rs
@@ -1,77 +1,21 @@
 //! Compressed account filtering via cuckoo filters.
 //!
-//! This module provides a probabilistic account filter for subscribe requests,
-//! aimed at clients tracking large pubkey sets (e.g., hundreds of thousands to
-//! millions). Instead of uploading an explicit pubkey list every few seconds,
-//! the client uploads a compact cuckoo filter — typically ~3 bytes per pubkey
-//! at 95% load — and the server matches accounts against it.
+//! For clients tracking large pubkey sets (100k–millions): instead of re-uploading an
+//! explicit pubkey list, the client uploads a compact cuckoo filter (~3 bytes/pubkey at
+//! 95% load) and the server matches accounts against it.
 //!
-//! # Primary API
+//! - [`CompressedAccountFilterSet`] — safe, tracked client-side builder (`convert` feature).
+//! - [`CuckooFilter`] — raw filter for server-side matching; has a `remove` footgun, so
+//!   clients should prefer [`CompressedAccountFilterSet`].
 //!
-//! - [`CompressedAccountFilterSet`] — safe, tracked client-side wrapper. Use this
-//!   to build filters. Requires the `convert` feature (enabled by default).
-//! - [`CuckooFilter`] — raw filter used for server-side matching. Has a `remove`
-//!   footgun; clients should prefer [`CompressedAccountFilterSet`].
-//!
-//! # Example — build, subscribe, then update without resubmitting the full list
-//!
-//! ```no_run
-//! use {
-//!     solana_pubkey::Pubkey,
-//!     yellowstone_grpc_proto::{cuckoo::CompressedAccountFilterSet, geyser::SubscribeRequest},
-//! };
-//!
-//! // 1. Build the cuckoo map for the accounts we track
-//! let mut accounts = CompressedAccountFilterSet::with_capacity(2_000_000).unwrap();
-//! for pk in my_tracked_pubkeys() {
-//!     accounts.insert(pk).unwrap();
-//! }
-//!
-//! // 2. Attach the compact filter to the subscribe request under a name we choose
-//! let mut req = SubscribeRequest::default();
-//! accounts.insert_into_subscribe_request(&mut req, "tracked_accounts");
-//! //    send `req` to the server...
-//!
-//! // 3. Mutate the tracked set as it changes
-//! accounts.insert(Pubkey::new_from_array([7u8; 32])).unwrap();
-//! accounts.remove(Pubkey::new_from_array([3u8; 32]));
-//!
-//! // 4. Only re-send when something changed — the filter is tiny, so a full
-//! //    re-send is cheap (no incremental-update protocol needed)
-//! if accounts.take_dirty() {
-//!     accounts.insert_into_subscribe_request(&mut req, "tracked_accounts");
-//!     // re-send `req` on the existing stream sink
-//! }
-//!
-//! # fn my_tracked_pubkeys() -> Vec<Pubkey> { vec![] }
-//! ```
-//!
-//! # Handling updates
-//!
-//! Account updates flowing in from the server may include false positives
-//! (bounded at <1% at full load). Filter locally with [`CompressedAccountFilterSet::contains`]
-//! for an exact check:
-//!
-//! ```no_run
-//! # use {
-//! #     solana_pubkey::Pubkey,
-//! #     yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet,
-//! # };
-//! # let accounts: CompressedAccountFilterSet = CompressedAccountFilterSet::with_capacity(100).unwrap();
-//! # let incoming_pubkey = Pubkey::new_from_array([0u8; 32]);
-//! if accounts.contains(incoming_pubkey) {
-//!     // definitely a tracked account
-//! } else {
-//!     // false positive from the server-side cuckoo check — ignore
-//! }
-//! ```
+//! Server-side matching accepts <1% false positives; clients re-check locally with
+//! [`CompressedAccountFilterSet::contains`].
 
 mod constants;
 mod error;
 mod filter;
 mod hasher;
-// `set` provides the client-side builder and needs `solana-pubkey`, which is
-// supplied by the `convert` feature. The server only needs the raw filter below.
+// Client-side builder; needs `solana-pubkey` via the `convert` feature. Server uses only the raw filter.
 #[cfg(feature = "convert")]
 mod set;
 

--- a/yellowstone-grpc-proto/src/cuckoo/set.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/set.rs
@@ -1,17 +1,9 @@
 //! Safe, tracked wrapper around [`CuckooFilter`] for client-side filter construction.
 //!
-//! [`CompressedAccountFilterSet`] is the primary user-facing type for building cuckoo filters to
-//! send in subscribe requests. It maintains an exact-membership [`HashSet`]
-//! alongside the probabilistic filter, which:
-//!
-//! - **Makes `remove` safe**: the filter is only mutated for items actually
-//!   present, avoiding the footgun where removing an un-inserted item clears
-//!   a different item sharing its fingerprint.
-//! - **Makes `contains` exact**: client-side membership checks return the
-//!   true answer, not a probabilistic one.
-//!
-//! The probabilistic filter is only used on the wire. Server-side matching
-//! accepts false positives (clients filter locally on receipt).
+//! [`CompressedAccountFilterSet`] keeps an exact [`HashSet`] alongside the probabilistic
+//! filter, so `remove` is safe (never evicts a fingerprint-colliding item) and `contains`
+//! is exact. The cuckoo filter is used only on the wire; the server accepts false positives
+//! and clients filter locally on receipt.
 //!
 //! [`HashSet`]: std::collections::HashSet
 
@@ -27,40 +19,13 @@ use {
     std::collections::HashSet,
 };
 
-/// A HashMap-like wrapper around [`CuckooFilter`] for safe filter construction.
+/// Safe builder for cuckoo filters sent in subscribe requests.
 ///
-/// Maintains two parallel collections:
-/// - A [`HashSet`] as the source of truth for exact membership
-/// - A [`CuckooFilter`] as the compact wire representation
+/// Holds two parallel collections: a [`HashSet`] (exact source of truth for `contains`/`len`
+/// and the guard for writes) and a [`CuckooFilter`] (compact wire form). Writes go to both;
+/// serialization reads the filter. Strictly safer than a raw [`CuckooFilter`], whose `remove`
+/// can silently evict the wrong fingerprint-colliding item.
 ///
-/// Writes go to both; reads (`contains`, `len`) answer from the [`HashSet`];
-/// serialization reads from the [`CuckooFilter`]. This gives users exact local
-/// semantics while producing a compact probabilistic filter for the server.
-///
-/// # When to Use
-///
-/// Use [`CompressedAccountFilterSet`] whenever you need to build a cuckoo filter to send in a
-/// subscribe request. It is strictly safer than constructing a [`CuckooFilter`]
-/// directly — the filter's `remove` method has a footgun (it can silently remove
-/// the wrong item when fingerprints collide), and [`CompressedAccountFilterSet`] guards against it.
-///
-/// # Example
-///
-/// ```
-/// use {
-///     solana_pubkey::Pubkey,
-///     yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet,
-/// };
-///
-/// let mut map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
-/// map.insert(Pubkey::new_from_array([42u8; 32])).unwrap();
-/// map.insert(Pubkey::new_from_array([100u8; 32])).unwrap();
-/// assert!(map.contains(Pubkey::new_from_array([42u8; 32])));
-/// assert_eq!(map.len(), 2);
-///
-/// map.remove(Pubkey::new_from_array([42u8; 32]));
-/// assert!(!map.contains(Pubkey::new_from_array([42u8; 32])));
-/// ```
 /// [`HashSet`]: std::collections::HashSet
 pub struct CompressedAccountFilterSet {
     items: HashSet<[u8; 32]>,
@@ -69,27 +34,8 @@ pub struct CompressedAccountFilterSet {
 }
 
 impl CompressedAccountFilterSet {
-    /// Creates an empty map pre-sized for up to `max_capacity` items.
-    ///
-    /// Both the internal [`HashSet`] and [`CuckooFilter`] are allocated up front
-    /// to avoid rehashing or reallocation during inserts.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CuckooBuildError::CapacityOverflow`] if `max_capacity` exceeds
-    /// what the system can allocate, or if the underlying cuckoo filter cannot
-    /// be built at the requested size.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
-    ///
-    /// let map = CompressedAccountFilterSet::with_capacity(10_000).unwrap();
-    /// assert!(map.is_empty());
-    /// ```
-    ///
-    /// [`HashSet`]: std::collections::HashSet
+    /// Empty map pre-sized for `max_capacity` items (both the `HashSet` and filter are
+    /// allocated up front). Errors [`CuckooBuildError::CapacityOverflow`] if it can't be allocated.
     pub fn with_capacity(max_capacity: usize) -> Result<Self, CuckooBuildError> {
         let filter = CuckooFilter::with_capacity(max_capacity)?;
 
@@ -105,21 +51,9 @@ impl CompressedAccountFilterSet {
         })
     }
 
-    /// Inserts an item into the map.
-    ///
-    /// Returns `Ok(true)` if the item was newly inserted, `Ok(false)` if it was
-    /// already present (idempotent).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`TableFullError`] if the underlying cuckoo filter is saturated and
-    /// cannot accommodate the item. This typically means the map was under-sized
-    /// for the workload; rebuild with a larger `max_capacity`.
-    ///
-    /// On error, the map's state is unchanged — neither the [`HashSet`] nor the
-    /// [`CuckooFilter`] is mutated.
-    ///
-    /// [`HashSet`]: std::collections::HashSet
+    /// Inserts a key. `Ok(true)` if newly added, `Ok(false)` if already present (idempotent).
+    /// Errors [`TableFullError`] if the filter is saturated (map under-sized); state is
+    /// unchanged on error.
     pub fn insert(&mut self, key: Pubkey) -> Result<bool, TableFullError> {
         let bytes = key.to_bytes();
 
@@ -132,20 +66,8 @@ impl CompressedAccountFilterSet {
         Ok(true)
     }
 
-    /// Removes an item from the map.
-    ///
-    /// Returns `true` if the item was present and removed, `false` if it was not
-    /// in the map.
-    ///
-    /// # Safety over [`CuckooFilter::remove`]
-    ///
-    /// The underlying [`CuckooFilter`] has a known footgun: removing an item that
-    /// was never inserted can silently remove a different item that shares the
-    /// same fingerprint. [`CompressedAccountFilterSet`] prevents this by checking its internal
-    /// [`HashSet`] first and only touching the filter when the item is genuinely
-    /// present.
-    ///
-    /// [`HashSet`]: std::collections::HashSet
+    /// Removes a key; returns whether it was present. Safe unlike [`CuckooFilter::remove`]:
+    /// checks the `HashSet` first and only touches the filter when the key genuinely exists.
     pub fn remove(&mut self, key: Pubkey) -> bool {
         let bytes = key.to_bytes();
 
@@ -158,12 +80,7 @@ impl CompressedAccountFilterSet {
         }
     }
 
-    /// Checks if an item is in the map.
-    ///
-    /// Unlike [`CuckooFilter::contains`], this returns an exact answer — the
-    /// [`HashSet`] guarantees no false positives.
-    ///
-    /// [`HashSet`]: std::collections::HashSet
+    /// Exact membership (from the `HashSet`, no false positives), unlike [`CuckooFilter::contains`].
     pub fn contains(&self, key: Pubkey) -> bool {
         self.items.contains(&key.to_bytes())
     }
@@ -173,32 +90,13 @@ impl CompressedAccountFilterSet {
         self.items.len()
     }
 
-    /// Returns the number of items the map can hold without reallocating.
-    ///
-    /// Typically larger than the `max_capacity` passed to [`with_capacity`],
-    /// the underlying [`HashSet`] rounds allocation up to its own sizing
-    /// policy. Use this to check remaining headroom before a batch of inserts
-    /// or to report occupancy alongside [`len`].
-    ///
-    /// ```
-    /// use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
-    ///
-    /// let map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
-    /// assert!(map.capacity() >= 1000);
-    /// ```
-    ///
-    /// [`with_capacity`]: CompressedAccountFilterSet::with_capacity
-    /// [`len`]: CompressedAccountFilterSet::len
-    /// [`HashSet`]: std::collections::HashSet
+    /// Items the map can hold without reallocating (≥ the `with_capacity` argument; the
+    /// `HashSet` rounds up). Useful for headroom checks before a batch of inserts.
     pub fn capacity(&self) -> usize {
         self.items.capacity()
     }
 
-    /// Returns an iterator over the items in the map in arbitrary order.
-    ///
-    /// Reads from the internal [`HashSet`], so iteration order matches
-    /// `HashSet` semantics; no ordering guarantee, and two calls on the
-    /// same map may yield items in different orders.
+    /// Iterates items in arbitrary `HashSet` order (no ordering guarantee).
     pub fn iter(&self) -> impl Iterator<Item = &[u8; 32]> {
         self.items.iter()
     }
@@ -208,72 +106,26 @@ impl CompressedAccountFilterSet {
         self.items.is_empty()
     }
 
-    /// Returns `true` if the map has been mutated since the last call to
-    /// [`take_dirty`] (or since construction).
-    ///
-    /// Use this to check whether the filter needs to be re-sent without
-    /// clearing the flag.
-    ///
-    /// [`take_dirty`]: CompressedAccountFilterSet::take_dirty
+    /// `true` if mutated since the last [`take_dirty`](Self::take_dirty) (or construction);
+    /// does not clear the flag.
     pub const fn is_dirty(&self) -> bool {
         self.dirty
     }
 
-    /// Returns the dirty flag and clears it.
-    ///
-    /// Call this when transmitting the filter: if it returns `true`, rebuild
-    /// and send; if `false`, skip the send. Clearing means subsequent
-    /// mutations will flip the flag back to `true` for the next cycle.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use {
-    ///     solana_pubkey::Pubkey,
-    ///     yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet,
-    /// };
-    ///
-    /// let mut map = CompressedAccountFilterSet::with_capacity(100).unwrap();
-    /// assert!(!map.take_dirty());    // fresh map is clean
-    ///
-    /// map.insert(Pubkey::new_from_array([42u8; 32])).unwrap();
-    /// assert!(map.take_dirty());     // mutation flipped it
-    /// assert!(!map.take_dirty());    // and clearing it takes effect
-    /// ```
+    /// Returns the dirty flag and clears it. Call when transmitting: `true` → rebuild and send.
     pub fn take_dirty(&mut self) -> bool {
         let dirty = self.dirty;
         self.dirty = false;
         dirty
     }
 
-    /// Serializes the underlying cuckoo filter to its proto wire format.
-    ///
-    /// The returned proto carries all parameters needed for deserialization on
-    /// the server side or in cross-language clients: bucket count, entries per
-    /// bucket, fingerprint bits, and the hash seed.
+    /// Serializes the cuckoo filter to proto wire format (carries bucket geometry + hash seed).
     pub fn to_proto(&self) -> ProtoCuckooFilter {
         ProtoCuckooFilter::from(&self.filter)
     }
 
-    /// Returns a `SubscribeRequestFilterAccounts` that carries only this cuckoo
-    /// filter in essence no explicit account list, no owner, no predicates.
-    ///
-    /// Use this when you want to add the cuckoo filter to a subscribe request
-    /// yourself, under a name of your choosing, alongside other account filters
-    /// or other subscription types:
-    ///
-    /// ```no_run
-    /// use {
-    ///     solana_pubkey::Pubkey,
-    ///     yellowstone_grpc_proto::{cuckoo::CompressedAccountFilterSet, geyser::SubscribeRequest},
-    /// };
-    ///
-    /// let mut map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
-    /// map.insert(Pubkey::new_from_array([1u8; 32])).unwrap();
-    ///
-    /// let mut req = SubscribeRequest::default();
-    /// req.accounts.insert("my_cuckoo".to_string(), map.to_account_filter());
-    /// ```
+    /// A `SubscribeRequestFilterAccounts` carrying only this cuckoo filter (no account list,
+    /// owner, or predicates) — add it to a request under a name of your choosing.
     pub fn to_account_filter(&self) -> SubscribeRequestFilterAccounts {
         SubscribeRequestFilterAccounts {
             account: vec![],
@@ -284,30 +136,8 @@ impl CompressedAccountFilterSet {
         }
     }
 
-    /// Inserts this cuckoo filter into `req.accounts` under the given name.
-    ///
-    /// Existing entries in `req.accounts` are preserved. If an entry already
-    /// exists under `name`, it is replaced. Other fields of `req` (transactions,
-    /// blocks, slots, etc.) are untouched.
-    ///
-    /// Marks the map as clean — subsequent mutations will flip the dirty flag
-    /// back to `true` for the next transmission cycle.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use {
-    ///     solana_pubkey::Pubkey,
-    ///     yellowstone_grpc_proto::{cuckoo::CompressedAccountFilterSet, geyser::SubscribeRequest},
-    /// };
-    ///
-    /// let mut map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
-    /// map.insert(Pubkey::new_from_array([1u8; 32])).unwrap();
-    ///
-    /// let mut req = SubscribeRequest::default();
-    /// map.insert_into_subscribe_request(&mut req, "tracked_accounts");
-    /// // req.accounts["tracked_accounts"] now carries the cuckoo filter
-    /// ```
+    /// Inserts this filter into `req.accounts` under `name` (replacing any existing entry,
+    /// preserving others) and marks the map clean.
     pub fn insert_into_subscribe_request(&mut self, req: &mut SubscribeRequest, name: &str) {
         req.accounts
             .insert(name.to_string(), self.to_account_filter());

--- a/yellowstone-grpc-proto/src/cuckoo/set.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/set.rs
@@ -1,0 +1,457 @@
+//! Safe, tracked wrapper around [`CuckooFilter`] for client-side filter construction.
+//!
+//! [`CompressedAccountFilterSet`] is the primary user-facing type for building cuckoo filters to
+//! send in subscribe requests. It maintains an exact-membership [`HashSet`]
+//! alongside the probabilistic filter, which:
+//!
+//! - **Makes `remove` safe**: the filter is only mutated for items actually
+//!   present, avoiding the footgun where removing an un-inserted item clears
+//!   a different item sharing its fingerprint.
+//! - **Makes `contains` exact**: client-side membership checks return the
+//!   true answer, not a probabilistic one.
+//!
+//! The probabilistic filter is only used on the wire. Server-side matching
+//! accepts false positives (clients filter locally on receipt).
+//!
+//! [`HashSet`]: std::collections::HashSet
+
+use {
+    super::{
+        error::{CuckooBuildError, TableFullError},
+        filter::CuckooFilter,
+    },
+    crate::geyser::{
+        CuckooFilter as ProtoCuckooFilter, SubscribeRequest, SubscribeRequestFilterAccounts,
+    },
+    solana_pubkey::Pubkey,
+    std::collections::HashSet,
+};
+
+/// A HashMap-like wrapper around [`CuckooFilter`] for safe filter construction.
+///
+/// Maintains two parallel collections:
+/// - A [`HashSet`] as the source of truth for exact membership
+/// - A [`CuckooFilter`] as the compact wire representation
+///
+/// Writes go to both; reads (`contains`, `len`) answer from the [`HashSet`];
+/// serialization reads from the [`CuckooFilter`]. This gives users exact local
+/// semantics while producing a compact probabilistic filter for the server.
+///
+/// # When to Use
+///
+/// Use [`CompressedAccountFilterSet`] whenever you need to build a cuckoo filter to send in a
+/// subscribe request. It is strictly safer than constructing a [`CuckooFilter`]
+/// directly — the filter's `remove` method has a footgun (it can silently remove
+/// the wrong item when fingerprints collide), and [`CompressedAccountFilterSet`] guards against it.
+///
+/// # Example
+///
+/// ```
+/// use {
+///     solana_pubkey::Pubkey,
+///     yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet,
+/// };
+///
+/// let mut map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
+/// map.insert(Pubkey::new_from_array([42u8; 32])).unwrap();
+/// map.insert(Pubkey::new_from_array([100u8; 32])).unwrap();
+/// assert!(map.contains(Pubkey::new_from_array([42u8; 32])));
+/// assert_eq!(map.len(), 2);
+///
+/// map.remove(Pubkey::new_from_array([42u8; 32]));
+/// assert!(!map.contains(Pubkey::new_from_array([42u8; 32])));
+/// ```
+/// [`HashSet`]: std::collections::HashSet
+pub struct CompressedAccountFilterSet {
+    items: HashSet<[u8; 32]>,
+    filter: CuckooFilter<[u8; 32]>,
+    dirty: bool,
+}
+
+impl CompressedAccountFilterSet {
+    /// Creates an empty map pre-sized for up to `max_capacity` items.
+    ///
+    /// Both the internal [`HashSet`] and [`CuckooFilter`] are allocated up front
+    /// to avoid rehashing or reallocation during inserts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CuckooBuildError::CapacityOverflow`] if `max_capacity` exceeds
+    /// what the system can allocate, or if the underlying cuckoo filter cannot
+    /// be built at the requested size.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
+    ///
+    /// let map = CompressedAccountFilterSet::with_capacity(10_000).unwrap();
+    /// assert!(map.is_empty());
+    /// ```
+    ///
+    /// [`HashSet`]: std::collections::HashSet
+    pub fn with_capacity(max_capacity: usize) -> Result<Self, CuckooBuildError> {
+        let filter = CuckooFilter::with_capacity(max_capacity)?;
+
+        let mut items: HashSet<[u8; 32]> = HashSet::new();
+        items
+            .try_reserve(max_capacity)
+            .map_err(|_| CuckooBuildError::CapacityOverflow)?;
+
+        Ok(Self {
+            items,
+            filter,
+            dirty: false,
+        })
+    }
+
+    /// Inserts an item into the map.
+    ///
+    /// Returns `Ok(true)` if the item was newly inserted, `Ok(false)` if it was
+    /// already present (idempotent).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TableFullError`] if the underlying cuckoo filter is saturated and
+    /// cannot accommodate the item. This typically means the map was under-sized
+    /// for the workload; rebuild with a larger `max_capacity`.
+    ///
+    /// On error, the map's state is unchanged — neither the [`HashSet`] nor the
+    /// [`CuckooFilter`] is mutated.
+    ///
+    /// [`HashSet`]: std::collections::HashSet
+    pub fn insert(&mut self, key: Pubkey) -> Result<bool, TableFullError> {
+        let bytes = key.to_bytes();
+
+        if self.items.contains(&bytes) {
+            return Ok(false);
+        }
+        self.filter.insert(&bytes)?;
+        self.items.insert(bytes);
+        self.dirty = true;
+        Ok(true)
+    }
+
+    /// Removes an item from the map.
+    ///
+    /// Returns `true` if the item was present and removed, `false` if it was not
+    /// in the map.
+    ///
+    /// # Safety over [`CuckooFilter::remove`]
+    ///
+    /// The underlying [`CuckooFilter`] has a known footgun: removing an item that
+    /// was never inserted can silently remove a different item that shares the
+    /// same fingerprint. [`CompressedAccountFilterSet`] prevents this by checking its internal
+    /// [`HashSet`] first and only touching the filter when the item is genuinely
+    /// present.
+    ///
+    /// [`HashSet`]: std::collections::HashSet
+    pub fn remove(&mut self, key: Pubkey) -> bool {
+        let bytes = key.to_bytes();
+
+        if self.items.remove(&bytes) {
+            self.filter.remove(&bytes);
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Checks if an item is in the map.
+    ///
+    /// Unlike [`CuckooFilter::contains`], this returns an exact answer — the
+    /// [`HashSet`] guarantees no false positives.
+    ///
+    /// [`HashSet`]: std::collections::HashSet
+    pub fn contains(&self, key: Pubkey) -> bool {
+        self.items.contains(&key.to_bytes())
+    }
+
+    /// Returns the number of items in the map.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns the number of items the map can hold without reallocating.
+    ///
+    /// Typically larger than the `max_capacity` passed to [`with_capacity`],
+    /// the underlying [`HashSet`] rounds allocation up to its own sizing
+    /// policy. Use this to check remaining headroom before a batch of inserts
+    /// or to report occupancy alongside [`len`].
+    ///
+    /// ```
+    /// use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
+    ///
+    /// let map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
+    /// assert!(map.capacity() >= 1000);
+    /// ```
+    ///
+    /// [`with_capacity`]: CompressedAccountFilterSet::with_capacity
+    /// [`len`]: CompressedAccountFilterSet::len
+    /// [`HashSet`]: std::collections::HashSet
+    pub fn capacity(&self) -> usize {
+        self.items.capacity()
+    }
+
+    /// Returns an iterator over the items in the map in arbitrary order.
+    ///
+    /// Reads from the internal [`HashSet`], so iteration order matches
+    /// `HashSet` semantics; no ordering guarantee, and two calls on the
+    /// same map may yield items in different orders.
+    pub fn iter(&self) -> impl Iterator<Item = &[u8; 32]> {
+        self.items.iter()
+    }
+
+    /// Returns `true` if the map contains no items.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns `true` if the map has been mutated since the last call to
+    /// [`take_dirty`] (or since construction).
+    ///
+    /// Use this to check whether the filter needs to be re-sent without
+    /// clearing the flag.
+    ///
+    /// [`take_dirty`]: CompressedAccountFilterSet::take_dirty
+    pub const fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Returns the dirty flag and clears it.
+    ///
+    /// Call this when transmitting the filter: if it returns `true`, rebuild
+    /// and send; if `false`, skip the send. Clearing means subsequent
+    /// mutations will flip the flag back to `true` for the next cycle.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use {
+    ///     solana_pubkey::Pubkey,
+    ///     yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet,
+    /// };
+    ///
+    /// let mut map = CompressedAccountFilterSet::with_capacity(100).unwrap();
+    /// assert!(!map.take_dirty());    // fresh map is clean
+    ///
+    /// map.insert(Pubkey::new_from_array([42u8; 32])).unwrap();
+    /// assert!(map.take_dirty());     // mutation flipped it
+    /// assert!(!map.take_dirty());    // and clearing it takes effect
+    /// ```
+    pub fn take_dirty(&mut self) -> bool {
+        let dirty = self.dirty;
+        self.dirty = false;
+        dirty
+    }
+
+    /// Serializes the underlying cuckoo filter to its proto wire format.
+    ///
+    /// The returned proto carries all parameters needed for deserialization on
+    /// the server side or in cross-language clients: bucket count, entries per
+    /// bucket, fingerprint bits, and the hash seed.
+    pub fn to_proto(&self) -> ProtoCuckooFilter {
+        ProtoCuckooFilter::from(&self.filter)
+    }
+
+    /// Returns a `SubscribeRequestFilterAccounts` that carries only this cuckoo
+    /// filter in essence no explicit account list, no owner, no predicates.
+    ///
+    /// Use this when you want to add the cuckoo filter to a subscribe request
+    /// yourself, under a name of your choosing, alongside other account filters
+    /// or other subscription types:
+    ///
+    /// ```no_run
+    /// use {
+    ///     solana_pubkey::Pubkey,
+    ///     yellowstone_grpc_proto::{cuckoo::CompressedAccountFilterSet, geyser::SubscribeRequest},
+    /// };
+    ///
+    /// let mut map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
+    /// map.insert(Pubkey::new_from_array([1u8; 32])).unwrap();
+    ///
+    /// let mut req = SubscribeRequest::default();
+    /// req.accounts.insert("my_cuckoo".to_string(), map.to_account_filter());
+    /// ```
+    pub fn to_account_filter(&self) -> SubscribeRequestFilterAccounts {
+        SubscribeRequestFilterAccounts {
+            account: vec![],
+            owner: vec![],
+            filters: vec![],
+            nonempty_txn_signature: None,
+            cuckoo_accounts_filter: Some(self.to_proto()),
+        }
+    }
+
+    /// Inserts this cuckoo filter into `req.accounts` under the given name.
+    ///
+    /// Existing entries in `req.accounts` are preserved. If an entry already
+    /// exists under `name`, it is replaced. Other fields of `req` (transactions,
+    /// blocks, slots, etc.) are untouched.
+    ///
+    /// Marks the map as clean — subsequent mutations will flip the dirty flag
+    /// back to `true` for the next transmission cycle.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use {
+    ///     solana_pubkey::Pubkey,
+    ///     yellowstone_grpc_proto::{cuckoo::CompressedAccountFilterSet, geyser::SubscribeRequest},
+    /// };
+    ///
+    /// let mut map = CompressedAccountFilterSet::with_capacity(1000).unwrap();
+    /// map.insert(Pubkey::new_from_array([1u8; 32])).unwrap();
+    ///
+    /// let mut req = SubscribeRequest::default();
+    /// map.insert_into_subscribe_request(&mut req, "tracked_accounts");
+    /// // req.accounts["tracked_accounts"] now carries the cuckoo filter
+    /// ```
+    pub fn insert_into_subscribe_request(&mut self, req: &mut SubscribeRequest, name: &str) {
+        req.accounts
+            .insert(name.to_string(), self.to_account_filter());
+        self.dirty = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // helper: a 32-byte key from a single seed byte
+    fn key(b: u8) -> Pubkey {
+        Pubkey::new_from_array([b; 32])
+    }
+
+    #[test]
+    fn basic_insert_contains() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        assert!(filter.insert(key(1)).unwrap());
+        assert!(filter.contains(key(1)));
+        assert!(!filter.contains(key(2)));
+    }
+
+    #[test]
+    fn insert_duplicate_returns_false() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        assert!(filter.insert(key(1)).unwrap());
+        assert!(!filter.insert(key(1)).unwrap());
+    }
+
+    #[test]
+    fn remove_existing() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        filter.insert(key(1)).unwrap();
+        assert!(filter.remove(key(1)));
+        assert!(!filter.contains(key(1)));
+    }
+
+    #[test]
+    fn remove_nonexistent_is_safe() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        filter.insert(key(1)).unwrap();
+
+        assert!(!filter.remove(key(2)));
+        assert!(filter.contains(key(1)));
+    }
+
+    #[test]
+    fn len_and_is_empty() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        assert!(filter.is_empty());
+        assert_eq!(filter.len(), 0);
+
+        filter.insert(key(1)).unwrap();
+        filter.insert(key(2)).unwrap();
+        assert!(!filter.is_empty());
+        assert_eq!(filter.len(), 2);
+
+        filter.remove(key(1));
+        assert_eq!(filter.len(), 1);
+    }
+
+    #[test]
+    fn to_proto_round_trip() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        filter.insert(key(1)).unwrap();
+        filter.insert(key(2)).unwrap();
+
+        let proto = filter.to_proto();
+        assert!(!proto.data.is_empty());
+        assert!(proto.bucket_count > 0);
+    }
+
+    #[test]
+    fn to_account_filter_carries_cuckoo_and_no_other_matchers() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        filter.insert(key(1)).unwrap();
+
+        let f = filter.to_account_filter();
+
+        assert!(f.cuckoo_accounts_filter.is_some());
+        assert!(f.account.is_empty());
+        assert!(f.owner.is_empty());
+        assert!(f.filters.is_empty());
+        assert_eq!(f.nonempty_txn_signature, None);
+    }
+
+    #[test]
+    fn insert_into_subscribe_request_uses_given_name_and_preserves_other_filters() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        filter.insert(key(1)).unwrap();
+
+        let mut req = SubscribeRequest::default();
+        req.accounts.insert(
+            "pre_existing".to_string(),
+            SubscribeRequestFilterAccounts::default(),
+        );
+
+        filter.insert_into_subscribe_request(&mut req, "tracked_accounts");
+
+        assert!(req.accounts.contains_key("tracked_accounts"));
+        assert!(req.accounts.contains_key("pre_existing"));
+        assert_eq!(req.accounts.len(), 2);
+        assert!(req
+            .accounts
+            .get("tracked_accounts")
+            .unwrap()
+            .cuckoo_accounts_filter
+            .is_some());
+    }
+
+    #[test]
+    fn insert_into_subscribe_request_clears_dirty_flag() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(100).unwrap();
+        filter.insert(key(1)).unwrap();
+        assert!(filter.is_dirty());
+
+        let mut req = SubscribeRequest::default();
+        filter.insert_into_subscribe_request(&mut req, "accounts");
+
+        assert!(!filter.is_dirty());
+    }
+
+    #[test]
+    fn pubkey_like_usage() {
+        let mut filter = CompressedAccountFilterSet::with_capacity(1000).unwrap();
+
+        for i in 0..100u8 {
+            filter.insert(key(i)).unwrap();
+        }
+
+        assert_eq!(filter.len(), 100);
+
+        for i in 0..100u8 {
+            assert!(filter.contains(key(i)));
+        }
+
+        assert!(!filter.contains(key(255)));
+    }
+
+    #[test]
+    fn capacity_overflow() {
+        let result = CompressedAccountFilterSet::with_capacity(usize::MAX);
+        assert!(matches!(result, Err(CuckooBuildError::CapacityOverflow)));
+    }
+}

--- a/yellowstone-grpc-proto/src/lib.rs
+++ b/yellowstone-grpc-proto/src/lib.rs
@@ -29,6 +29,8 @@ pub mod solana {
     }
 }
 
+pub mod cuckoo;
+
 pub mod prelude {
     pub use super::{geyser::*, solana::storage::confirmed_block::*};
 }


### PR DESCRIPTION
## Summary

Backport of upstream [`rpcpool/yellowstone-grpc#732`](https://github.com/rpcpool/yellowstone-grpc/pull/732) (cuckoo "compressed account filters") onto this fork's `subscribe-raw-client-with-unconfirmed-v9.0.1` base — the branch the live Laserstream server compiles against. The diff here is exactly the cuckoo addition on top of what production runs today.

Lets clients track millions of accounts on one connection by sending a compact cuckoo filter (~3 bytes/account fingerprints) instead of explicit 32-byte pubkeys. Matching has **no false negatives** and **<1% false positives** (the client re-filters locally against its exact set).

## What's added (purely additive — 0 deletions)

- **`geyser.proto`** — `CuckooFilter` message, `CuckooHashAlgorithm` enum, optional `cuckoo_accounts_filter` on `SubscribeRequestFilterAccounts`.
- **`yellowstone-grpc-proto/src/cuckoo/`** — the reusable library:
  - `filter.rs`: runtime `CuckooFilter<T>` (insert/contains/remove, partial-key cuckoo hashing, proto round-trip) — the server-side matcher.
  - `set.rs`: `CompressedAccountFilterSet` — client builder (exact `HashSet` + cuckoo, dirty tracking, `insert_into_subscribe_request`); gated on the `convert` feature.
  - `hasher.rs`: `YellowstoneHasherBuilder` (SipHash-2-4; seed carried on the wire so client and server compute identical fingerprints across languages/versions).
  - `constants.rs`, `error.rs`, `mod.rs`.
- `siphasher` dependency; `pub mod cuckoo` in `lib.rs`.

## Differences from the upstream commit

- **Dropped** the upstream geyser-plugin filter integration (`plugin/filter/`) — Laserstream matches in its own `richat-filter`, which has diverged from upstream, so a cherry-pick there would conflict heavily for no benefit.
- Error types use hand-written `Display`/`Error` impls instead of `thiserror` (optional dep in this crate version).
- `CompressedAccountFilterSet::take_dirty` avoids `std::mem::replace` (consumer style rule).

## Testing

48 cuckoo unit tests pass — matcher insert/contains/remove, capacity/overflow, proto round-trip, and the client set (dedup, safe remove, dirty tracking, subscribe-request wiring). Verified end-to-end against a live richat with `yellowstone-grpc-client` + `CompressedAccountFilterSet`: 2744-account filter → 8 KB on the wire (~10× smaller), 318k updates delivered, 100% in the tracked set, 0 false positives, 0 false negatives.

## Consumer

Required by helius-labs/monorepo#15647, which pins its git ref to this branch.