### PR TITLE
Switch token_accounts to TokenAccountExpansionControlFlag enum

### DIFF
--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -484,6 +484,7 @@ impl Action {
                             owner: args.accounts_owner.clone(),
                             filters,
                             nonempty_txn_signature: args.accounts_nonempty_txn_signature,
+                            cuckoo_accounts_filter: None,
                         },
                     );
                 }

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -148,9 +148,20 @@ message SubscribeRequestFilterTransactions {
   repeated string account_include = 3;
   repeated string account_exclude = 4;
   repeated string account_required = 6;
-  // Helius extension: ATA / token-account expansion control.
-  // One of "none" (default), "balanceChanged", "all".
-  optional string token_accounts = 30;
+  // Helius extension: ATA / token-account expansion control. When set,
+  // account_include / account_exclude / account_required also match
+  // against owners of pre/post token balances on each transaction.
+  // Absent = no expansion.
+  optional TokenAccountExpansionControlFlag token_accounts = 30;
+}
+
+// Helius extension: discriminator for `SubscribeRequestFilterTransactions.token_accounts`.
+enum TokenAccountExpansionControlFlag {
+  // Match an owner if it owns a pre OR post token balance on the tx.
+  ALL = 0;
+  // Match an owner whose token balance changed in amount (per
+  // `account_index`) or whose token account was closed.
+  BALANCE_CHANGED = 1;
 }
 
 message SubscribeRequestFilterBlocks {

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -1222,6 +1222,7 @@ mod tests {
                 account: vec![],
                 owner: vec![],
                 filters: vec![],
+                cuckoo_accounts_filter: None,
             },
         );
 
@@ -1520,6 +1521,7 @@ mod tests {
                 account_include,
                 account_exclude: vec![],
                 account_required,
+                token_accounts: None,
             },
         );
 
@@ -1593,6 +1595,7 @@ mod tests {
                 account_include,
                 account_exclude: vec![],
                 account_required,
+                token_accounts: None,
             },
         );
 


### PR DESCRIPTION
## Summary

Replaces `optional string token_accounts` on `SubscribeRequestFilterTransactions` with a proper enum:

```proto
enum TokenAccountExpansionControlFlag {
  ALL = 0;
  BALANCE_CHANGED = 1;
}
optional TokenAccountExpansionControlFlag token_accounts = 30;
```

Matches the shape we agreed on with Triton in [rpcpool/yellowstone-grpc#762](https://github.com/rpcpool/yellowstone-grpc/pull/762) (see `lvboudre`'s review). Keeps the same field number (30) so the wire layout stays aligned with upstream once #762 lands.

## Wire-format note

This is a **breaking proto change**. Old clients/servers encoded `token_accounts` as length-delimited string at tag 30; new ones encode it as varint i32 at tag 30. Different wire types, so mismatched pairs will silently ignore the field (decode as missing). Acceptable here because:

- The field is unused on the server side of this fork. Laserstream uses its own ATA filter implementation, not the yellowstone-grpc-geyser one.
- There are no live SDK clients using `tokenAccounts` yet. A separate monorepo migration moves the server-side reader / canaries / SDK to the new shape in lockstep.

## Drive-by fixes

The branch had pre-existing struct-init breakage (E0063) from when `cuckoo_accounts_filter` and `token_accounts` were added without updating every fixture / example literal. Fixed:

- 3 `SubscribeRequestFilterTransactions` test fixtures in `yellowstone-grpc-proto/src/plugin/filter/filter.rs`
- 1 `SubscribeRequestFilterAccounts` test fixture in the same file
- 1 `SubscribeRequestFilterAccounts` literal in `examples/rust/src/bin/client.rs`

`cargo build --workspace --all-targets` clean. `cargo test --workspace` 65/65 pass.

## Next step after merge

Publish `laserstream-core-proto` 9.3.0 from the merged tip so the monorepo can pin to it by version.