### PR TITLE
Add cuckoo_account_include to SubscribeRequestFilterTransactions

### DIFF
--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -148,6 +148,10 @@ message SubscribeRequestFilterTransactions {
   repeated string account_include = 3;
   repeated string account_exclude = 4;
   repeated string account_required = 6;
+  // Helius extension: compact cuckoo filter for account_include. OR-combined
+  // with the explicit account_include set; lets clients track very large
+  // include sets (millions) without re-uploading explicit pubkeys.
+  optional CuckooFilter cuckoo_account_include = 7;
   // Helius extension: ATA / token-account expansion control. When set,
   // account_include / account_exclude / account_required also match
   // against owners of pre/post token balances on each transaction.

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -148,9 +148,8 @@ message SubscribeRequestFilterTransactions {
   repeated string account_include = 3;
   repeated string account_exclude = 4;
   repeated string account_required = 6;
-  // Helius extension: compact cuckoo filter for account_include. OR-combined
-  // with the explicit account_include set; lets clients track very large
-  // include sets (millions) without re-uploading explicit pubkeys.
+  // Helius extension: compact cuckoo filter for account_include, OR-combined
+  // with the explicit account_include set.
   optional CuckooFilter cuckoo_account_include = 7;
   // Helius extension: ATA / token-account expansion control. When set,
   // account_include / account_exclude / account_required also match

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -1259,6 +1259,7 @@ mod tests {
                 account_include: vec![],
                 account_exclude: vec![],
                 account_required: vec![],
+                cuckoo_account_include: None,
                 token_accounts: None,
             },
         );
@@ -1295,6 +1296,7 @@ mod tests {
                 account_include: vec![],
                 account_exclude: vec![],
                 account_required: vec![],
+                cuckoo_account_include: None,
                 token_accounts: None,
             },
         );
@@ -1337,6 +1339,7 @@ mod tests {
                 account_include,
                 account_exclude: vec![],
                 account_required: vec![],
+                cuckoo_account_include: None,
                 token_accounts: None,
             },
         );
@@ -1403,6 +1406,7 @@ mod tests {
                 account_include,
                 account_exclude: vec![],
                 account_required: vec![],
+                cuckoo_account_include: None,
                 token_accounts: None,
             },
         );
@@ -1469,6 +1473,7 @@ mod tests {
                 account_include: vec![],
                 account_exclude,
                 account_required: vec![],
+                cuckoo_account_include: None,
                 token_accounts: None,
             },
         );
@@ -1521,6 +1526,7 @@ mod tests {
                 account_include,
                 account_exclude: vec![],
                 account_required,
+                cuckoo_account_include: None,
                 token_accounts: None,
             },
         );
@@ -1595,6 +1601,7 @@ mod tests {
                 account_include,
                 account_exclude: vec![],
                 account_required,
+                cuckoo_account_include: None,
                 token_accounts: None,
             },
         );


### PR DESCRIPTION
Adds `cuckoo_account_include` (field 7) to `SubscribeRequestFilterTransactions`, a compact cuckoo filter OR-combined with the explicit `account_include` set so clients can track very large include sets (millions of pubkeys) without re-uploading them. Mirrors the existing `cuckoo_accounts_filter` on the accounts filter.

This is a clean re-create of the change previously on `cuckoo-txn-account-include-v9.0.1`, cut fresh from current `subscribe-raw-client-with-unconfirmed-v9.0.1` so it merges cleanly into the durable base (the old branch had diverged — it predated the `token_accounts` enum switch in #37). This keeps `token_accounts` as the `TokenAccountExpansionControlFlag` enum from base and only adds the cuckoo field.

Why merge into the base branch: the Helius monorepo pins yellowstone to this base branch. Landing the field here (rather than leaving it on a deletable feature branch) means the monorepo can pin to the durable base — avoiding the build breakage that happens when a pinned feature branch is deleted after squash-merge.

- proto: `+optional CuckooFilter cuckoo_account_include = 7;`
- filter.rs: `cuckoo_account_include: None` added to existing test fixtures
- `cargo build -p yellowstone-grpc-proto`: ok
- `cargo test -p yellowstone-grpc-proto`: 48 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)