### PR TITLE
Add Diff Only Account Filter and Modified Flag to Geyser Proto

### DIFF
--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -485,6 +485,7 @@ impl Action {
                             filters,
                             nonempty_txn_signature: args.accounts_nonempty_txn_signature,
                             cuckoo_accounts_filter: None,
+                            diff_only: None,
                         },
                     );
                 }

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -92,6 +92,8 @@ message SubscribeRequestFilterAccounts {
   repeated SubscribeRequestFilterAccountsFilter filters = 4;
   optional bool nonempty_txn_signature = 5;
   optional CuckooFilter cuckoo_accounts_filter = 6;
+  // Suppress updates the validator marked as not modified (modified == false).
+  optional bool diff_only = 7;
 }
 
 // Hash algorithm for a CuckooFilter (on the wire for forward-compat).
@@ -223,6 +225,9 @@ message SubscribeUpdateAccountInfo {
   bytes data = 6;
   uint64 write_version = 7;
   optional bytes txn_signature = 8;
+  // Whether the transaction actually changed this account's state.
+  // Unset when unknown (old validator or non-transaction store).
+  optional bool modified = 9;
 }
 
 message SubscribeUpdateSlot {

--- a/yellowstone-grpc-proto/src/cuckoo/set.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/set.rs
@@ -133,6 +133,7 @@ impl CompressedAccountFilterSet {
             filters: vec![],
             nonempty_txn_signature: None,
             cuckoo_accounts_filter: Some(self.to_proto()),
+            diff_only: None,
         }
     }
 

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -261,6 +261,7 @@ impl Filter {
 struct FilterAccounts {
     nonempty_txn_signature: Vec<(FilterName, Option<bool>)>,
     nonempty_txn_signature_required: HashSet<FilterName>,
+    diff_only: HashSet<FilterName>,
     account: HashMap<Pubkey, HashSet<FilterName>>,
     account_required: HashSet<FilterName>,
     owner: HashMap<Pubkey, HashSet<FilterName>>,
@@ -283,6 +284,9 @@ impl FilterAccounts {
             if filter.nonempty_txn_signature.is_some() {
                 this.nonempty_txn_signature_required
                     .insert(names.get(name)?);
+            }
+            if filter.diff_only == Some(true) {
+                this.diff_only.insert(names.get(name)?);
             }
 
             FilterLimits::check_any(
@@ -340,6 +344,7 @@ impl FilterAccounts {
         accounts_data_slice: &FilterAccountsDataSlice,
     ) -> FilteredUpdates {
         let mut filter = FilterAccountsMatch::new(self);
+        filter.match_modified(message.account.modified);
         filter.match_txn_signature(&message.account.txn_signature);
         filter.match_account(&message.account.pubkey);
         filter.match_owner(&message.account.owner);
@@ -505,6 +510,7 @@ struct FilterAccountsMatch<'a> {
     account: HashSet<&'a str>,
     owner: HashSet<&'a str>,
     data: HashSet<&'a str>,
+    modified: Option<bool>,
 }
 
 impl<'a> FilterAccountsMatch<'a> {
@@ -515,7 +521,12 @@ impl<'a> FilterAccountsMatch<'a> {
             account: Default::default(),
             owner: Default::default(),
             data: Default::default(),
+            modified: None,
         }
+    }
+
+    fn match_modified(&mut self, modified: Option<bool>) {
+        self.modified = modified;
     }
 
     fn extend(
@@ -568,6 +579,12 @@ impl<'a> FilterAccountsMatch<'a> {
                 if af.nonempty_txn_signature_required.contains(name)
                     && !self.nonempty_txn_signature.contains(name)
                 {
+                    return None;
+                }
+                // diff_only: suppress only when the validator positively said
+                // "unchanged". None (old validator or non-transaction store)
+                // must deliver — never silently miss an update.
+                if af.diff_only.contains(name) && self.modified == Some(false) {
                     return None;
                 }
                 if af.account_required.contains(name) && !self.account.contains(name) {
@@ -1223,6 +1240,7 @@ mod tests {
                 owner: vec![],
                 filters: vec![],
                 cuckoo_accounts_filter: None,
+                diff_only: None,
             },
         );
 

--- a/yellowstone-grpc-proto/src/plugin/filter/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/message.rs
@@ -187,6 +187,7 @@ impl FilteredUpdate {
             data: data_slice.get_slice(&message.data),
             write_version: message.write_version,
             txn_signature: message.txn_signature.map(|s| s.as_ref().into()),
+            modified: message.modified,
         }
     }
 
@@ -554,6 +555,10 @@ impl FilteredUpdateAccount {
         if let Some(value) = &account.txn_signature {
             prost_bytes_encode_raw(8u32, value.as_ref(), buf);
         }
+        // Some(false) must go on the wire — it is the suppression signal.
+        if let Some(value) = &account.modified {
+            ::prost::encoding::bool::encode(9u32, value, buf);
+        }
     }
 
     fn account_encoded_len(
@@ -592,6 +597,9 @@ impl FilteredUpdateAccount {
             + account
                 .txn_signature
                 .map_or(0, |sig| prost_bytes_encoded_len(8u32, sig.as_ref()))
+            + account
+                .modified
+                .map_or(0, |value| ::prost::encoding::bool::encoded_len(9u32, &value))
     }
 }
 
@@ -1098,16 +1106,19 @@ pub mod tests {
                     ] {
                         for write_version in [0, 1] {
                             for txn_signature in [None, Some(txn_signature)] {
-                                accounts.push(Arc::new(MessageAccountInfo {
-                                    pubkey,
-                                    lamports,
-                                    owner,
-                                    executable,
-                                    rent_epoch,
-                                    data: data.clone(),
-                                    write_version,
-                                    txn_signature,
-                                }));
+                                for modified in [None, Some(true), Some(false)] {
+                                    accounts.push(Arc::new(MessageAccountInfo {
+                                        pubkey,
+                                        lamports,
+                                        owner,
+                                        executable,
+                                        rent_epoch,
+                                        data: data.clone(),
+                                        write_version,
+                                        txn_signature,
+                                        modified,
+                                    }));
+                                }
                             }
                         }
                     }

--- a/yellowstone-grpc-proto/src/plugin/message.rs
+++ b/yellowstone-grpc-proto/src/plugin/message.rs
@@ -193,6 +193,9 @@ pub struct MessageAccountInfo {
     pub data: Vec<u8>,
     pub write_version: u64,
     pub txn_signature: Option<Signature>,
+    /// Whether the transaction actually changed this account's state.
+    /// `None` when unknown (old validator or non-transaction store).
+    pub modified: Option<bool>,
 }
 
 impl MessageAccountInfo {
@@ -206,6 +209,8 @@ impl MessageAccountInfo {
             data: info.data.into(),
             write_version: info.write_version,
             txn_signature: info.txn.map(|txn| *txn.signature()),
+            // ReplicaAccountInfoV3 does not carry the modified flag.
+            modified: None,
         }
     }
 
@@ -224,6 +229,7 @@ impl MessageAccountInfo {
                     Signature::try_from(sig.as_slice()).map_err(|_| "invalid signature length")
                 })
                 .transpose()?,
+            modified: msg.modified,
         })
     }
 }


### PR DESCRIPTION
## Summary

- `SubscribeRequestFilterAccounts`: new `optional bool diff_only = 7` — suppress account updates the producer positively marked as unmodified
- `SubscribeUpdateAccountInfo`: new `optional bool modified = 9` — whether the transaction actually changed this account's state; unset when unknown

Suppression rule: drop an update iff `diff_only == true` and `modified == Some(false)`. Updates without the flag always deliver, so consumers never silently miss changes from producers that do not set it. The plugin module carries the field through `MessageAccountInfo`, the account filter, and the manual wire encoder (`Some(false)` is always encoded — it is the suppression signal).

Both fields are additive and optional; existing subscribers and producers are unaffected.

## Testing

`cargo test -p yellowstone-grpc-proto --features plugin`: 65/65, including the encode byte-identity matrix extended over `modified in [None, Some(true), Some(false)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)