### PR TITLE
[LS-228] Rename AccountState Enum to NotifyOn (Lock/Write)

### DIFF
--- a/examples/rust/src/bin/client.rs
+++ b/examples/rust/src/bin/client.rs
@@ -485,7 +485,7 @@ impl Action {
                             filters,
                             nonempty_txn_signature: args.accounts_nonempty_txn_signature,
                             cuckoo_accounts_filter: None,
-                            account_state: 0, // ACCOUNT_STATE_LOCKED (default)
+                            notify_on: 0, // NOTIFY_ON_LOCK (default)
                         },
                     );
                 }

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -86,14 +86,14 @@ message SubscribeRequest {
   optional uint64 from_slot = 11;
 }
 
-// Which account updates a subscriber wants delivered. `LOCKED` (the default,
-// zero-value) keeps current behavior: every write-locked account. `WRITTEN`
+// Which account updates a subscriber wants delivered. `LOCK` (the default,
+// zero-value) keeps current behavior: every write-locked account. `WRITE`
 // opts into delivery of only accounts a transaction actually mutated, dropping
-// write-locked-but-unchanged ones. Laserstream enforces `WRITTEN` using its
+// write-locked-but-unchanged ones. Laserstream enforces `WRITE` using its
 // internal is_unmodified ingest signal.
-enum AccountState {
-  ACCOUNT_STATE_LOCKED = 0;
-  ACCOUNT_STATE_WRITTEN = 1;
+enum NotifyOn {
+  NOTIFY_ON_LOCK = 0;
+  NOTIFY_ON_WRITE = 1;
 }
 
 message SubscribeRequestFilterAccounts {
@@ -102,11 +102,11 @@ message SubscribeRequestFilterAccounts {
   repeated SubscribeRequestFilterAccountsFilter filters = 4;
   optional bool nonempty_txn_signature = 5;
   optional CuckooFilter cuckoo_accounts_filter = 6;
-  // Client opt-in: which write-locked accounts to deliver. Unset / LOCKED =
-  // current behavior (all); WRITTEN = only mutated accounts.
+  // Client opt-in: which write-locked accounts to deliver. Unset / LOCK =
+  // current behavior (all); WRITE = only mutated accounts.
   // High tag number: this is a Helius-internal extension, kept clear of the
   // low-numbered range upstream may extend.
-  AccountState account_state = 31;
+  NotifyOn notify_on = 31;
 }
 
 // Hash algorithm for a CuckooFilter (on the wire for forward-compat).

--- a/yellowstone-grpc-proto/src/cuckoo/set.rs
+++ b/yellowstone-grpc-proto/src/cuckoo/set.rs
@@ -133,7 +133,7 @@ impl CompressedAccountFilterSet {
             filters: vec![],
             nonempty_txn_signature: None,
             cuckoo_accounts_filter: Some(self.to_proto()),
-            account_state: 0, // ACCOUNT_STATE_LOCKED (default)
+            notify_on: 0, // NOTIFY_ON_LOCK (default)
         }
     }
 

--- a/yellowstone-grpc-proto/src/plugin/filter/filter.rs
+++ b/yellowstone-grpc-proto/src/plugin/filter/filter.rs
@@ -1223,7 +1223,7 @@ mod tests {
                 owner: vec![],
                 filters: vec![],
                 cuckoo_accounts_filter: None,
-                account_state: 0, // ACCOUNT_STATE_LOCKED (default)
+                notify_on: 0, // NOTIFY_ON_LOCK (default)
             },
         );
 


### PR DESCRIPTION
## Summary
Client-facing rename of the account_state opt-in: proto enum `AccountState` -> `NotifyOn`, variants `ACCOUNT_STATE_LOCKED/WRITTEN` -> `NOTIFY_ON_LOCK/WRITE`, field `account_state` -> `notify_on`.

## Wire compatibility
Field tag **31** and enum values **0/1 unchanged** — this is a pure source-level rename. Old and new clients/servers interoperate (proto matches by tag+value, not name).

## Changes
- `geyser.proto`: enum + field rename (tag 31 kept).
- 3 field initializers (`account_state: 0` -> `notify_on: 0`) in examples/client.rs, cuckoo/set.rs, plugin/filter.rs.
- Untouched: the unrelated `token_account_state` filter.

## Verification
- `cargo build -p yellowstone-grpc-proto` clean (default features); regenerated `geyser.rs` has `enum NotifyOn` + `notify_on` at tag 31.
- The monorepo + SDK pin to this branch and build clean against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)