### PR TITLE
proto: add match_mints transaction-filter flag

### DIFF
--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -169,9 +169,7 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
-  // Helius extension: when true, account_include / account_exclude /
-  // account_required also match against the mints of pre/post token balances.
-  // Catches classic SPL `Transfer`s, whose keys never contain the mint.
+  // Helius extension: also match the account lists against pre/post token-balance mints.
   bool match_mints = 32;
 }
 

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -169,6 +169,10 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
+  // Helius extension: when true, account_include / account_exclude /
+  // account_required also match against the mints of pre/post token balances.
+  // Catches classic SPL `Transfer`s, whose keys never contain the mint.
+  bool match_mints = 32;
 }
 
 // Helius extension: discriminator for `SubscribeRequestFilterTransactions.token_accounts`.

--- a/yellowstone-grpc-proto/proto/geyser.proto
+++ b/yellowstone-grpc-proto/proto/geyser.proto
@@ -169,7 +169,7 @@ message SubscribeRequestFilterTransactions {
   // against owners of pre/post token balances on each transaction.
   // Absent = no expansion.
   optional TokenAccountExpansionControlFlag token_accounts = 30;
-  // Helius extension: also match the account lists against pre/post token-balance mints.
+  // Also match the account lists against pre/post token-balance mints.
   bool match_mints = 32;
 }
 


### PR DESCRIPTION
## Summary

Adds `bool match_mints = 32` to `SubscribeRequestFilterTransactions`. When set, Laserstream matches `account_include` / `account_exclude` / `account_required` against the mints of pre/post token balances in addition to account keys — catches classic SPL `Transfer`s, whose keys never contain the mint.

Wire-compatible with the server-side implementation in helius-labs/monorepo#18758 (same field number and semantics on both the external and internal protos there). Field 32 is free on this branch (30 = token_accounts, 31 = cuckoo_account_include).

## Purpose

Needed to publish the next `laserstream-core-proto` release so the LaserStream SDKs (Rust/JS napi) can construct requests with the flag — same flow as the `token_accounts` field (#48 pattern).

Made with [Cursor](https://cursor.com)